### PR TITLE
handle resources deleted outside of terraform

### DIFF
--- a/internal/provider/resource_athena_connection.go
+++ b/internal/provider/resource_athena_connection.go
@@ -84,13 +84,6 @@ func (t athenaConnectionResourceType) NewResource(ctx context.Context, in provid
 	}, diags
 }
 
-type athenaConfigurationData struct {
-	AccessKeyId     types.String `tfsdk:"access_key_id"`
-	AccessKeySecret types.String `tfsdk:"access_key_secret"`
-	Region          types.String `tfsdk:"region"`
-	OutputBucket    types.String `tfsdk:"output_bucket"`
-}
-
 type athenaConnectionResource struct {
 	provider ptProvider
 }
@@ -141,6 +134,10 @@ func (r athenaConnectionResource) Read(ctx context.Context, req resource.ReadReq
 
 	connection, err := r.provider.client.Connections().Get(ctx, uuid.MustParse(data.Id.Value))
 	if err != nil {
+		if err.Error() == ConnectionNotFoundErr {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error reading connection: %s", err))
 		return
 	}

--- a/internal/provider/resource_connection.go
+++ b/internal/provider/resource_connection.go
@@ -4,6 +4,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+const (
+	ConnectionNotFoundErr = "no connection found (404)"
+)
+
 type connectionResourceData struct {
 	Organization  types.String `tfsdk:"organization"`
 	Name          types.String `tfsdk:"name"`

--- a/internal/provider/resource_sqlserver_connection.go
+++ b/internal/provider/resource_sqlserver_connection.go
@@ -84,13 +84,6 @@ func (t sqlserverConnectionResourceType) NewResource(ctx context.Context, in pro
 	}, diags
 }
 
-type sqlserverConfigurationData struct {
-	AccessKeyId     types.String `tfsdk:"access_key_id"`
-	AccessKeySecret types.String `tfsdk:"access_key_secret"`
-	Region          types.String `tfsdk:"region"`
-	OutputBucket    types.String `tfsdk:"output_bucket"`
-}
-
 type sqlserverConnectionResource struct {
 	provider ptProvider
 }
@@ -142,6 +135,10 @@ func (r sqlserverConnectionResource) Read(ctx context.Context, req resource.Read
 
 	connection, err := r.provider.client.Connections().Get(ctx, uuid.MustParse(data.Id.Value))
 	if err != nil {
+		if err.Error() == ConnectionNotFoundErr {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error reading connection: %s", err))
 		return
 	}

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -145,6 +145,10 @@ func (r userResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error reading user: %s", err))
 		return
 	}
+	if user.ID == uuid.Nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	data.Id = types.String{Value: user.ID.String()}
 	data.Organization = types.String{Value: user.OrganizationId.String()}


### PR DESCRIPTION
Closes #3 

This PR addresses in-application state drift from terraform state. When resources are deleted in polytomic but not the terraform config, terraform will re-create the resources. This make terraform the ultimate "source of truth."