### PR TITLE
Add tooling for building and testing provider locally

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,3 +7,17 @@ default: testacc
 .PHONY: testacc
 testacc:
 	POLYTOMIC_DEPLOYMENT_URL=$(POLYTOMIC_DEPLOYMENT_URL) POLYTOMIC_DEPLOYMENT_KEY=$(POLYTOMIC_DEPLOYMENT_KEY) TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
+
+
+.PHONY: dev
+dev:
+	@echo "==> Setting up environment..."
+	./hack/setup_local.sh
+	@echo
+	@echo "==> Building provider..."
+	go generate
+	@echo
+	./hack/build.sh
+	@echo
+	@echo "==> Creating templated terraform project..."
+	./hack/template.sh

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# This script builds the polytomic terraform provider
+# and installs it in the local terraform plugin directory.
+set -e
+
+source $(dirname $0)/common.sh
+
+echo "Building provider..."
+go install
+
+echo "Copying provider to local terraform plugin directory..."
+cp $GOPATH/bin/terraform-provider-polytomic $LOCAL_PROVIDER_PATH

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+LOCAL_VERSION="99.0.0"
+PLUGIN_DIR="$HOME/.terraform.d/plugins"
+MODULE_PATH="terraform.local/local/polytomic"
+TEMPLATE_DIR="$HOME/polytomic-terraform-test"
+
+
+# Get operating system and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
+
+LOCAL_PROVIDER_PATH="$PLUGIN_DIR/$MODULE_PATH/$LOCAL_VERSION/${OS}_${ARCH}"

--- a/hack/setup_local.sh
+++ b/hack/setup_local.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# This script sets up a local development environment for the polytomic terraform provider.
+set -e
+
+source $(dirname $0)/common.sh
+
+echo "Writing .terraformrc config... "
+cat <<EOF > ~/.terraformrc
+provider_installation {
+  filesystem_mirror {
+    path    = "$PLUGIN_DIR"
+  }
+  direct {
+    exclude = ["terraform.local/*/*"]
+  }
+}
+EOF
+echo ".terraformrc config written"
+
+echo "Creating local provider directory ${LOCAL_PROVIDER_PATH} ... "
+mkdir -p $LOCAL_PROVIDER_PATH
+
+cat <<EOF
+
+Ensure the following block is set in your terraform configuration:
+
+terraform {
+  required_providers {
+    polytomic = {
+      source  = "$MODULE_PATH"
+      version = "$LOCAL_VERSION"
+    }
+  }
+}
+EOF

--- a/hack/template.sh
+++ b/hack/template.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+source $(dirname $0)/common.sh
+
+
+mkdir -p $TEMPLATE_DIR
+
+cat <<EOF > $TEMPLATE_DIR/main.tf
+terraform {
+  required_providers {
+    polytomic = {
+      source  = "$MODULE_PATH"
+      version = "$LOCAL_VERSION"
+    }
+  }
+}
+
+provider "polytomic" {
+  deployment_url     = "app.polytomic-local.com:8443"
+  deployment_api_key = "secret-key"
+}
+EOF
+
+rm -rf $TEMPLATE_DIR/.terraform
+rm -f $TEMPLATE_DIR/.terraform.lock.hcl
+
+pushd $TEMPLATE_DIR
+terraform init
+popd
+
+echo "Created templated terraform project in $TEMPLATE_DIR"


### PR DESCRIPTION
I have to remind myself how to build and setup the provider to get terraform to run the new version locally every time. This PR is tooling so I don't have to keep re-teaching myself the same thing. Hopefully, others can benefit from this also.

There's a collection of scripts which are coordinated via the Makefile.

- `hack/common.sh` sets up common variables
- `hack/setup_local.sh`sets up a local provider path and configures `.terraformrc` to use our local mirror
- `hack/build.sh` installs the provider locally to the `$GOPATH` and copies it to our mirror path
- `hack/template.sh` creates and inits a skeleton project to test the built provider with.


All this is wrapped with `make dev`