### PR TITLE
Add support for importing connections as data sources

### DIFF
--- a/importer/connections.go
+++ b/importer/connections.go
@@ -85,7 +85,7 @@ func (c *Connections) GenerateTerraformFiles(ctx context.Context, writer io.Writ
 	for _, conn := range c.Datasources {
 		hclFile := hclwrite.NewEmptyFile()
 		body := hclFile.Body()
-		resourceBlock := body.AppendNewBlock("datasource", []string{conn.Resource, provider.ToSnakeCase(conn.Name)})
+		resourceBlock := body.AppendNewBlock("data", []string{conn.Resource, provider.ToSnakeCase(conn.Name)})
 		resourceBlock.Body().SetAttributeValue("id", cty.StringVal(conn.ID))
 		resourceBlock.Body().SetAttributeValue("name", cty.StringVal(conn.Name))
 		resourceBlock.Body().SetAttributeValue("organization", cty.StringVal(conn.Organization))

--- a/provider/connections.go
+++ b/provider/connections.go
@@ -81,7 +81,7 @@ var (
 		func() datasource.DataSource { return &StripeConnectionDataSource{} },
 	}
 
-	connectionImportableResourcess = map[string]resource.Resource{
+	connectionImportableResources = map[string]resource.Resource{
 		"postgresql": &PostgresqlConnectionResource{},
 		"bigquery":   &BigqueryConnectionResource{},
 		"gcs":        &GcsConnectionResource{},
@@ -116,8 +116,40 @@ var (
 	}
 
 	connectionImportableDatasources = map[string]datasource.DataSource{
-		"gsheets":    &GsheetsConnectionDataSource{},
-		"hubspot":	&HubspotConnectionDataSource{},
+		"postgresql": &PostgresqlConnectionDataSource{},
+		"bigquery":   &BigqueryConnectionDataSource{},
+		"gcs":        &GcsConnectionDataSource{},
+		"azureblob":  &AzureblobConnectionDataSource{},
+		"s3":         &S3ConnectionDataSource{},
+		"sqlserver":  &SqlserverConnectionDataSource{},
+		"athena":     &AthenaConnectionDataSource{},
 		"salesforce": &SalesforceConnectionDataSource{},
+		"hubspot":    &HubspotConnectionDataSource{},
+		"googleads":  &GoogleadsConnectionDataSource{},
+		"gsheets":    &GsheetsConnectionDataSource{},
+		"snowflake":  &SnowflakeConnectionDataSource{},
+		"affinity":   &AffinityConnectionDataSource{},
+		"airtable":   &AirtableConnectionDataSource{},
+		"amplitude":  &AmplitudeConnectionDataSource{},
+		"marketo":    &MarketoConnectionDataSource{},
+		"mongodb":    &MongodbConnectionDataSource{},
+		"chargebee":  &ChargebeeConnectionDataSource{},
+		"cloudsql":   &CloudsqlConnectionDataSource{},
+		"cosmosdb":   &CosmosdbConnectionDataSource{},
+		"customerio": &CustomerioConnectionDataSource{},
+		"dialpad":    &DialpadConnectionDataSource{},
+		"freshdesk":  &FreshdeskConnectionDataSource{},
+		"fullstory":  &FullstoryConnectionDataSource{},
+		"harmonic":   &HarmonicConnectionDataSource{},
+		"intercom":   &IntercomConnectionDataSource{},
+		"klaviyo":    &KlaviyoConnectionDataSource{},
+		"kustomer":   &KustomerConnectionDataSource{},
+		"lob":        &LobConnectionDataSource{},
+		"mysql":      &MysqlConnectionDataSource{},
+		"netsuite":   &NetsuiteConnectionDataSource{},
+		"pipedrive":  &PipedriveConnectionDataSource{},
+		"redshift":   &RedshiftConnectionDataSource{},
+		"segment":    &SegmentConnectionDataSource{},
+		"stripe":     &StripeConnectionDataSource{},
 	}
 )

--- a/provider/connections.go
+++ b/provider/connections.go
@@ -81,7 +81,7 @@ var (
 		func() datasource.DataSource { return &StripeConnectionDataSource{} },
 	}
 
-	connectionImportables = map[string]resource.Resource{
+	connectionImportableResourcess = map[string]resource.Resource{
 		"postgresql": &PostgresqlConnectionResource{},
 		"bigquery":   &BigqueryConnectionResource{},
 		"gcs":        &GcsConnectionResource{},
@@ -113,5 +113,11 @@ var (
 		"redshift":   &RedshiftConnectionResource{},
 		"segment":    &SegmentConnectionResource{},
 		"stripe":     &StripeConnectionResource{},
+	}
+
+	connectionImportableDatasources = map[string]datasource.DataSource{
+		"gsheets":    &GsheetsConnectionDataSource{},
+		"hubspot":	&HubspotConnectionDataSource{},
+		"salesforce": &SalesforceConnectionDataSource{},
 	}
 )

--- a/provider/connections_common.go
+++ b/provider/connections_common.go
@@ -31,7 +31,7 @@ type connectionData struct {
 // with any additional connections that are not generated.
 func connectionsMap() map[string]resource.Resource {
 	conns := make(map[string]resource.Resource)
-	for k, v := range connectionImportableResourcess {
+	for k, v := range connectionImportableResources {
 		conns[k] = v
 	}
 	conns["api"] = &APIConnectionResource{}

--- a/provider/connections_common.go
+++ b/provider/connections_common.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -10,8 +11,13 @@ const (
 )
 
 var (
-	// ConnectionsMap is a map of all the connections that can be imported
+	// ConnectionsMap is a map of all the connections that can be imported as
+	// resources.
 	ConnectionsMap = connectionsMap()
+
+	// ConnectionDatasourcesMap is a map of all the connections that can be
+	// imported as data sources.
+	ConnectionDatasourcesMap = datasourcesMap()
 )
 
 type connectionData struct {
@@ -25,10 +31,18 @@ type connectionData struct {
 // with any additional connections that are not generated.
 func connectionsMap() map[string]resource.Resource {
 	conns := make(map[string]resource.Resource)
-	for k, v := range connectionImportables {
+	for k, v := range connectionImportableResourcess {
 		conns[k] = v
 	}
 	conns["api"] = &APIConnectionResource{}
 
 	return conns
+}
+
+func datasourcesMap() map[string]datasource.DataSource {
+	sources := make(map[string]datasource.DataSource)
+	for k, v := range connectionImportableDatasources {
+		sources[k] = v
+	}
+	return sources
 }

--- a/provider/gen/connections/connections.go.tmpl
+++ b/provider/gen/connections/connections.go.tmpl
@@ -11,19 +11,25 @@ import 	(
 var (
 	connectionResources =  []func() resource.Resource{
                 {{- range .Resources }}
-		func() resource.Resource { return &{{ . }}{} },
+		func() resource.Resource { return &{{ .ResourceName }}{} },
                 {{- end }}
 	}
 
 	connectionDatasources =  []func() datasource.DataSource{
                 {{- range .Datasources }}
-		func() datasource.DataSource { return &{{ . }}{} },
+		func() datasource.DataSource { return &{{ .ResourceName }}{} },
                 {{- end }}
 	}
 
-	connectionImportables = map[string]resource.Resource {
-			{{- range .Importables }}
+	connectionImportableResources = map[string]resource.Resource {
+			{{- range .Resources }}
 		"{{ .Name }}": &{{ .ResourceName }}{},
-				{{- end }}		
+				{{- end }}
+	}
+
+	connectionImportableDatasources = map[string]datasource.DataSource {
+			{{- range .Datasources }}
+		"{{ .Name }}": &{{ .ResourceName }}{},
+				{{- end }}
 	}
 )


### PR DESCRIPTION
We do not current support creating OAuth connections via the Terraform provider. In order to allow users to import their current configuration, we can instead import them as data sources.