### PR TITLE
Replace literal ids with referential ids

### DIFF
--- a/importer/connections.go
+++ b/importer/connections.go
@@ -25,8 +25,8 @@ var (
 type Connections struct {
 	c *polytomic.Client
 
-	Resources   []Connection
-	Datasources []Connection
+	Resources   map[string]Connection
+	Datasources map[string]Connection
 }
 
 type Connection struct {
@@ -40,7 +40,9 @@ type Connection struct {
 
 func NewConnections(c *polytomic.Client) *Connections {
 	return &Connections{
-		c: c,
+		c:           c,
+		Resources:   make(map[string]Connection),
+		Datasources: make(map[string]Connection),
 	}
 }
 
@@ -50,30 +52,31 @@ func (c *Connections) Init(ctx context.Context) error {
 		return err
 	}
 	for _, conn := range conns {
+		name := provider.ValidName(provider.ToSnakeCase(conn.Name))
 		if r, ok := provider.ConnectionsMap[conn.Type.ID]; ok {
 			resp := &resource.MetadataResponse{}
 			r.Metadata(ctx, resource.MetadataRequest{
 				ProviderTypeName: provider.Name,
 			}, resp)
-			c.Resources = append(c.Resources, Connection{
+			c.Resources[name] = Connection{
 				ID:            conn.ID,
 				Resource:      resp.TypeName,
 				Name:          conn.Name,
 				Organization:  conn.OrganizationId,
 				Configuration: conn.Configuration,
-			})
+			}
 
 		} else if d, ok := provider.ConnectionDatasourcesMap[conn.Type.ID]; ok {
 			resp := &datasource.MetadataResponse{}
 			d.Metadata(ctx, datasource.MetadataRequest{
 				ProviderTypeName: provider.Name,
 			}, resp)
-			c.Datasources = append(c.Datasources, Connection{
+			c.Datasources[name] = Connection{
 				ID:           conn.ID,
 				Resource:     resp.TypeName,
 				Name:         conn.Name,
 				Organization: conn.OrganizationId,
-			})
+			}
 		} else {
 			log.Warn().Msgf("connection type %s not supported", conn.Type.ID)
 		}
@@ -81,24 +84,24 @@ func (c *Connections) Init(ctx context.Context) error {
 	return nil
 }
 
-func (c *Connections) GenerateTerraformFiles(ctx context.Context, writer io.Writer) error {
-	for _, conn := range c.Datasources {
+func (c *Connections) GenerateTerraformFiles(ctx context.Context, writer io.Writer, refs map[string]string) error {
+	for name, conn := range c.Datasources {
 		hclFile := hclwrite.NewEmptyFile()
 		body := hclFile.Body()
-		resourceBlock := body.AppendNewBlock("data", []string{conn.Resource, provider.ValidName(provider.ToSnakeCase(conn.Name))})
+		resourceBlock := body.AppendNewBlock("data", []string{conn.Resource, name})
 		resourceBlock.Body().SetAttributeValue("id", cty.StringVal(conn.ID))
 		resourceBlock.Body().SetAttributeValue("name", cty.StringVal(conn.Name))
 		resourceBlock.Body().SetAttributeValue("organization", cty.StringVal(conn.Organization))
 		body.AppendNewline()
 
-		writer.Write(hclFile.Bytes())
+		writer.Write(ReplaceRefs(hclFile.Bytes(), refs))
 	}
 
-	for _, conn := range c.Resources {
+	for name, conn := range c.Resources {
 		config := typeConverter(conn.Configuration)
 		hclFile := hclwrite.NewEmptyFile()
 		body := hclFile.Body()
-		resourceBlock := body.AppendNewBlock("resource", []string{conn.Resource, provider.ToSnakeCase(conn.Name)})
+		resourceBlock := body.AppendNewBlock("resource", []string{conn.Resource, name})
 		resourceBlock.Body().SetAttributeValue("name", cty.StringVal(conn.Name))
 		resourceBlock.Body().SetAttributeValue("organization", cty.StringVal(conn.Organization))
 		resourceBlock.Body().SetAttributeValue("configuration", config)
@@ -111,10 +114,10 @@ func (c *Connections) GenerateTerraformFiles(ctx context.Context, writer io.Writ
 }
 
 func (c *Connections) GenerateImports(ctx context.Context, writer io.Writer) error {
-	for _, conn := range c.Resources {
+	for name, conn := range c.Resources {
 		writer.Write([]byte(fmt.Sprintf("terraform import %s.%s %s",
 			conn.Resource,
-			provider.ValidName(provider.ToSnakeCase(conn.Name)),
+			name,
 			conn.ID)))
 		writer.Write([]byte(fmt.Sprintf(" # %s\n", conn.Name)))
 	}
@@ -123,4 +126,20 @@ func (c *Connections) GenerateImports(ctx context.Context, writer io.Writer) err
 
 func (c *Connections) Filename() string {
 	return ConnectionsResourceFileName
+}
+
+func (c *Connections) ResourceRefs() map[string]string {
+	result := make(map[string]string)
+	for name, conn := range c.Resources {
+		result[conn.ID] = fmt.Sprintf("%s.%s.id", conn.Resource, name)
+	}
+	return result
+}
+
+func (c *Connections) DatasourceRefs() map[string]string {
+	result := make(map[string]string)
+	for name, conn := range c.Datasources {
+		result[conn.ID] = fmt.Sprintf("%s.%s.id", conn.Resource, name)
+	}
+	return result
 }

--- a/importer/main.go
+++ b/importer/main.go
@@ -44,7 +44,7 @@ func (m *Main) Init(ctx context.Context) error {
 	return nil
 }
 
-func (m *Main) GenerateTerraformFiles(ctx context.Context, writer io.Writer) error {
+func (m *Main) GenerateTerraformFiles(ctx context.Context, writer io.Writer, refs map[string]string) error {
 	tmpl, err := template.New("main").Parse(mainTemplate)
 	if err != nil {
 		return err
@@ -70,4 +70,12 @@ func (m *Main) GenerateImports(ctx context.Context, writer io.Writer) error {
 
 func (m *Main) Filename() string {
 	return "main.tf"
+}
+
+func (m *Main) ResourceRefs() map[string]string {
+	return nil
+}
+
+func (m *Main) DatasourceRefs() map[string]string {
+	return nil
 }

--- a/provider/resource_bulk_sync.go
+++ b/provider/resource_bulk_sync.go
@@ -97,11 +97,17 @@ func (r *bulkSyncResource) Schema(ctx context.Context, req resource.SchemaReques
 						MarkdownDescription: "",
 						Optional:            true,
 						Computed:            true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"day_of_month": schema.StringAttribute{
 						MarkdownDescription: "",
 						Optional:            true,
 						Computed:            true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 				},
 				Required: true,
@@ -117,31 +123,6 @@ func (r *bulkSyncResource) Schema(ctx context.Context, req resource.SchemaReques
 			},
 		},
 	}
-}
-
-func (r *bulkSyncResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	if req.State.Raw.IsNull() || !req.State.Raw.IsKnown() {
-		return
-	}
-
-	config := &bulkSyncResourceData{}
-	resp.Diagnostics.Append(req.Config.Get(ctx, config)...)
-
-	plan := &bulkSyncResourceData{}
-	resp.Diagnostics.Append(req.Plan.Get(ctx, plan)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	keys := []string{"day_of_week", "hour", "minute", "month", "day_of_month"}
-	for _, key := range keys {
-		if config.Schedule.Attributes()[key].IsNull() {
-			plan.Schedule.Attributes()[key] = types.StringValue("")
-		}
-	}
-
-	resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
-
 }
 
 func (r *bulkSyncResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -214,7 +195,10 @@ func (r *bulkSyncResource) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	var schedule polytomic.Schedule
-	diags = data.Schedule.As(ctx, &schedule, basetypes.ObjectAsOptions{})
+	diags = data.Schedule.As(ctx, &schedule, basetypes.ObjectAsOptions{
+		UnhandledNullAsEmpty:    true,
+		UnhandledUnknownAsEmpty: true,
+	})
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -335,7 +319,10 @@ func (r *bulkSyncResource) Update(ctx context.Context, req resource.UpdateReques
 	}
 
 	var schedule polytomic.Schedule
-	diags = data.Schedule.As(ctx, &schedule, basetypes.ObjectAsOptions{})
+	diags = data.Schedule.As(ctx, &schedule, basetypes.ObjectAsOptions{
+		UnhandledNullAsEmpty:    true,
+		UnhandledUnknownAsEmpty: true,
+	})
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/provider/resource_model.go
+++ b/provider/resource_model.go
@@ -120,27 +120,6 @@ func (r *modelResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 	}
 }
 
-func (r *modelResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	if req.State.Raw.IsNull() || !req.State.Raw.IsKnown() {
-		return
-	}
-	config := &modelResourceResourceData{}
-	resp.Diagnostics.Append(req.Config.Get(ctx, config)...)
-
-	plan := &modelResourceResourceData{}
-	resp.Diagnostics.Append(req.Plan.Get(ctx, plan)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	if config.Identifier.IsNull() {
-		plan.Identifier = types.StringValue("")
-	}
-
-	resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
-
-}
-
 func (r *modelResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	// Prevent panic if the provider has not been configured.
 	if req.ProviderData == nil {


### PR DESCRIPTION
In a perfect world, we could walk the hcl syntax tree and replace the values, however, most of the libraries I've found don't export the structs/interfaces required for doing this. For now, we can rely on regex.

This PR extends the `Importable` by adding two methods: `ResourceRefs` and `DatasourceRefs` these both return a mapping of polytomic resource IDs to the referential terraform resource IDs