### PR TITLE
Ensure generated HCL ordering is deterministic

### DIFF
--- a/importer/bulk_syncs.go
+++ b/importer/bulk_syncs.go
@@ -50,7 +50,8 @@ func (b *BulkSyncs) Init(ctx context.Context) error {
 }
 
 func (b *BulkSyncs) GenerateTerraformFiles(ctx context.Context, writer io.Writer, refs map[string]string) error {
-	for name, bulkSync := range b.Resources {
+	for _, name := range sortedKeys(b.Resources) {
+		bulkSync := b.Resources[name]
 		bulkSchemas, err := b.c.Bulk().GetBulkSyncSchemas(ctx, bulkSync.ID)
 		if err != nil {
 			return err
@@ -90,7 +91,8 @@ func (b *BulkSyncs) GenerateTerraformFiles(ctx context.Context, writer io.Writer
 }
 
 func (b *BulkSyncs) GenerateImports(ctx context.Context, writer io.Writer) error {
-	for name, bulkSync := range b.Resources {
+	for _, name := range sortedKeys(b.Resources) {
+		bulkSync := b.Resources[name]
 		writer.Write([]byte(fmt.Sprintf("terraform import %s.%s %s",
 			BulkSyncResource,
 			name,

--- a/importer/connections.go
+++ b/importer/connections.go
@@ -85,7 +85,8 @@ func (c *Connections) Init(ctx context.Context) error {
 }
 
 func (c *Connections) GenerateTerraformFiles(ctx context.Context, writer io.Writer, refs map[string]string) error {
-	for name, conn := range c.Datasources {
+	for _, name := range sortedKeys(c.Datasources) {
+		conn := c.Datasources[name]
 		hclFile := hclwrite.NewEmptyFile()
 		body := hclFile.Body()
 		resourceBlock := body.AppendNewBlock("data", []string{conn.Resource, name})
@@ -97,7 +98,8 @@ func (c *Connections) GenerateTerraformFiles(ctx context.Context, writer io.Writ
 		writer.Write(ReplaceRefs(hclFile.Bytes(), refs))
 	}
 
-	for name, conn := range c.Resources {
+	for _, name := range sortedKeys(c.Resources) {
+		conn := c.Resources[name]
 		config := typeConverter(conn.Configuration)
 		hclFile := hclwrite.NewEmptyFile()
 		body := hclFile.Body()
@@ -114,7 +116,8 @@ func (c *Connections) GenerateTerraformFiles(ctx context.Context, writer io.Writ
 }
 
 func (c *Connections) GenerateImports(ctx context.Context, writer io.Writer) error {
-	for name, conn := range c.Resources {
+	for _, name := range sortedKeys(c.Resources) {
+		conn := c.Resources[name]
 		writer.Write([]byte(fmt.Sprintf("terraform import %s.%s %s",
 			conn.Resource,
 			name,

--- a/importer/formatter.go
+++ b/importer/formatter.go
@@ -196,10 +196,11 @@ func wrapJSONEncode(v interface{}, wrapped ...string) hclwrite.Tokens {
 }
 
 // jsonEncodeMap wraps the given attribute names with a jsonencode function.
-func jsonEncodeMap(v map[string]any, wrapped ...string) hclwrite.Tokens {
+func jsonEncodeMap(m map[string]any, wrapped ...string) hclwrite.Tokens {
 	var tokens hclwrite.Tokens
 	tokens = append(tokens, &hclwrite.Token{Bytes: []byte("{\n")})
-	for k, v := range v {
+	for _, k := range sortedKeys(m) {
+		v := m[k]
 		value := typeConverter(v)
 		if value == cty.NilVal {
 			continue
@@ -222,13 +223,4 @@ func jsonEncodeMap(v map[string]any, wrapped ...string) hclwrite.Tokens {
 	tokens = append(tokens, &hclwrite.Token{Bytes: []byte("}")})
 
 	return tokens
-}
-
-// referenceTokens takes in reference
-// and returns an unquoted value as hclwrite.Tokens
-func referenceTokens(ref string) hclwrite.Tokens {
-	return hclwrite.Tokens{
-		&hclwrite.Token{Bytes: []byte(" ")},
-		&hclwrite.Token{Bytes: []byte(ref)},
-	}
 }

--- a/importer/models.go
+++ b/importer/models.go
@@ -66,7 +66,8 @@ func (m *Models) Init(ctx context.Context) error {
 }
 
 func (m *Models) GenerateTerraformFiles(ctx context.Context, writer io.Writer, refs map[string]string) error {
-	for name, model := range m.Resources {
+	for _, name := range sortedKeys(m.Resources) {
+		model := m.Resources[name]
 		hclFile := hclwrite.NewEmptyFile()
 		body := hclFile.Body()
 
@@ -121,7 +122,8 @@ func (m *Models) GenerateTerraformFiles(ctx context.Context, writer io.Writer, r
 }
 
 func (m *Models) GenerateImports(ctx context.Context, writer io.Writer) error {
-	for _, model := range m.Resources {
+	for _, name := range sortedKeys(m.Resources) {
+		model := m.Resources[name]
 		writer.Write([]byte(fmt.Sprintf("terraform import %s.%s %s",
 			ModelResource,
 			m.modelNames[model.ID],

--- a/importer/policy.go
+++ b/importer/policy.go
@@ -57,7 +57,8 @@ func (p *Policies) Init(ctx context.Context) error {
 }
 
 func (p *Policies) GenerateTerraformFiles(ctx context.Context, writer io.Writer, refs map[string]string) error {
-	for name, policy := range p.Resources {
+	for _, name := range sortedKeys(p.Resources) {
+		policy := p.Resources[name]
 		hclFile := hclwrite.NewEmptyFile()
 		body := hclFile.Body()
 
@@ -83,7 +84,8 @@ func (p *Policies) GenerateTerraformFiles(ctx context.Context, writer io.Writer,
 }
 
 func (p *Policies) GenerateImports(ctx context.Context, writer io.Writer) error {
-	for name, policy := range p.Resources {
+	for _, name := range sortedKeys(p.Resources) {
+		policy := p.Resources[name]
 		writer.Write([]byte(fmt.Sprintf("terraform import %s.%s %s",
 			PolicyResource,
 			name,

--- a/importer/role.go
+++ b/importer/role.go
@@ -53,7 +53,8 @@ func (r *Roles) Init(ctx context.Context) error {
 }
 
 func (r *Roles) GenerateTerraformFiles(ctx context.Context, writer io.Writer, refs map[string]string) error {
-	for name, role := range r.Resources {
+	for _, name := range sortedKeys(r.Resources) {
+		role := r.Resources[name]
 		hclFile := hclwrite.NewEmptyFile()
 		body := hclFile.Body()
 		resourceBlock := body.AppendNewBlock("resource", []string{RoleResource, name})
@@ -68,7 +69,8 @@ func (r *Roles) GenerateTerraformFiles(ctx context.Context, writer io.Writer, re
 }
 
 func (r *Roles) GenerateImports(ctx context.Context, writer io.Writer) error {
-	for name, role := range r.Resources {
+	for _, name := range sortedKeys(r.Resources) {
+		role := r.Resources[name]
 		writer.Write([]byte(fmt.Sprintf("terraform import %s.%s %s",
 			RoleResource,
 			name,

--- a/importer/syncs.go
+++ b/importer/syncs.go
@@ -49,7 +49,8 @@ func (s *Syncs) Init(ctx context.Context) error {
 }
 
 func (s *Syncs) GenerateTerraformFiles(ctx context.Context, writer io.Writer, refs map[string]string) error {
-	for name, sync := range s.Resources {
+	for _, name := range sortedKeys(s.Resources) {
+		sync := s.Resources[name]
 		hclFile := hclwrite.NewEmptyFile()
 		body := hclFile.Body()
 		resourceBlock := body.AppendNewBlock("resource", []string{SyncResource, name})
@@ -123,7 +124,8 @@ func (s *Syncs) GenerateTerraformFiles(ctx context.Context, writer io.Writer, re
 }
 
 func (s *Syncs) GenerateImports(ctx context.Context, writer io.Writer) error {
-	for name, sync := range s.Resources {
+	for _, name := range sortedKeys(s.Resources) {
+		sync := s.Resources[name]
 		writer.Write([]byte(fmt.Sprintf("terraform import %s.%s %s",
 			SyncResource,
 			name,

--- a/importer/util.go
+++ b/importer/util.go
@@ -1,0 +1,12 @@
+package importer
+
+import "sort"
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}


### PR DESCRIPTION
This PR implements lexicographical ordering of resources and attributes prior to writing. The inconsistent ordering mainly affected cases where we had to generate raw tokens for things like json encoded maps. Any calls to `SetAttributeValue` should be fine since when constructing tokens it uses the [ElementIterator](https://github.com/zclconf/go-cty/blob/v1.13.3/cty/value_ops.go#L1166-L1190) under the hood which sorts the keys whilst constructing tokens in ascending lexicographical order