### PR TITLE
Add `force_destroy` attribute to connection resources

### DIFF
--- a/docs/resources/affinity_connection.md
+++ b/docs/resources/affinity_connection.md
@@ -31,6 +31,7 @@ resource "polytomic_affinity_connection" "affinity" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/airtable_connection.md
+++ b/docs/resources/airtable_connection.md
@@ -31,6 +31,7 @@ resource "polytomic_airtable_connection" "airtable" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/amplitude_connection.md
+++ b/docs/resources/amplitude_connection.md
@@ -32,6 +32,7 @@ resource "polytomic_amplitude_connection" "amplitude" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/api_connection.md
+++ b/docs/resources/api_connection.md
@@ -37,6 +37,7 @@ resource "polytomic_api_connection" "example" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/asana_connection.md
+++ b/docs/resources/asana_connection.md
@@ -31,6 +31,7 @@ resource "polytomic_asana_connection" "asana" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/ascend_connection.md
+++ b/docs/resources/ascend_connection.md
@@ -31,6 +31,7 @@ resource "polytomic_ascend_connection" "ascend" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/athena_connection.md
+++ b/docs/resources/athena_connection.md
@@ -34,6 +34,7 @@ resource "polytomic_athena_connection" "athena" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/azureblob_connection.md
+++ b/docs/resources/azureblob_connection.md
@@ -33,6 +33,7 @@ resource "polytomic_azureblob_connection" "azureblob" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/bigquery_connection.md
+++ b/docs/resources/bigquery_connection.md
@@ -33,6 +33,7 @@ resource "polytomic_bigquery_connection" "bigquery" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/chargebee_connection.md
+++ b/docs/resources/chargebee_connection.md
@@ -32,6 +32,7 @@ resource "polytomic_chargebee_connection" "chargebee" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/cloudsql_connection.md
+++ b/docs/resources/cloudsql_connection.md
@@ -34,6 +34,7 @@ resource "polytomic_cloudsql_connection" "cloudsql" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/cosmosdb_connection.md
+++ b/docs/resources/cosmosdb_connection.md
@@ -32,6 +32,7 @@ resource "polytomic_cosmosdb_connection" "cosmosdb" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/csv_connection.md
+++ b/docs/resources/csv_connection.md
@@ -51,6 +51,7 @@ resource "polytomic_csv_connection" "example" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/customerio_connection.md
+++ b/docs/resources/customerio_connection.md
@@ -33,6 +33,7 @@ resource "polytomic_customerio_connection" "customerio" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/databricks_connection.md
+++ b/docs/resources/databricks_connection.md
@@ -38,6 +38,7 @@ resource "polytomic_databricks_connection" "databricks" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/delighted_connection.md
+++ b/docs/resources/delighted_connection.md
@@ -31,6 +31,7 @@ resource "polytomic_delighted_connection" "delighted" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/dialpad_connection.md
+++ b/docs/resources/dialpad_connection.md
@@ -31,6 +31,7 @@ resource "polytomic_dialpad_connection" "dialpad" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/dynamodb_connection.md
+++ b/docs/resources/dynamodb_connection.md
@@ -33,6 +33,7 @@ resource "polytomic_dynamodb_connection" "dynamodb" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/freshdesk_connection.md
+++ b/docs/resources/freshdesk_connection.md
@@ -32,6 +32,7 @@ resource "polytomic_freshdesk_connection" "freshdesk" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/fullstory_connection.md
+++ b/docs/resources/fullstory_connection.md
@@ -31,6 +31,7 @@ resource "polytomic_fullstory_connection" "fullstory" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/gcs_connection.md
+++ b/docs/resources/gcs_connection.md
@@ -33,6 +33,7 @@ resource "polytomic_gcs_connection" "gcs" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/harmonic_connection.md
+++ b/docs/resources/harmonic_connection.md
@@ -31,6 +31,7 @@ resource "polytomic_harmonic_connection" "harmonic" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/intercom_connection.md
+++ b/docs/resources/intercom_connection.md
@@ -31,6 +31,7 @@ resource "polytomic_intercom_connection" "intercom" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/jira_connection.md
+++ b/docs/resources/jira_connection.md
@@ -35,6 +35,7 @@ resource "polytomic_jira_connection" "jira" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/klaviyo_connection.md
+++ b/docs/resources/klaviyo_connection.md
@@ -31,6 +31,7 @@ resource "polytomic_klaviyo_connection" "klaviyo" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/kustomer_connection.md
+++ b/docs/resources/kustomer_connection.md
@@ -32,6 +32,7 @@ resource "polytomic_kustomer_connection" "kustomer" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/linear_connection.md
+++ b/docs/resources/linear_connection.md
@@ -31,6 +31,7 @@ resource "polytomic_linear_connection" "linear" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/lob_connection.md
+++ b/docs/resources/lob_connection.md
@@ -31,6 +31,7 @@ resource "polytomic_lob_connection" "lob" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/marketo_connection.md
+++ b/docs/resources/marketo_connection.md
@@ -33,6 +33,7 @@ resource "polytomic_marketo_connection" "marketo" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/mongodb_connection.md
+++ b/docs/resources/mongodb_connection.md
@@ -34,6 +34,7 @@ resource "polytomic_mongodb_connection" "mongodb" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/mysql_connection.md
+++ b/docs/resources/mysql_connection.md
@@ -36,6 +36,7 @@ resource "polytomic_mysql_connection" "mysql" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/netsuite_connection.md
+++ b/docs/resources/netsuite_connection.md
@@ -33,6 +33,7 @@ resource "polytomic_netsuite_connection" "netsuite" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/pipedrive_connection.md
+++ b/docs/resources/pipedrive_connection.md
@@ -32,6 +32,7 @@ resource "polytomic_pipedrive_connection" "pipedrive" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/postgresql_connection.md
+++ b/docs/resources/postgresql_connection.md
@@ -35,6 +35,7 @@ resource "polytomic_postgresql_connection" "postgresql" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/redshift_connection.md
+++ b/docs/resources/redshift_connection.md
@@ -39,6 +39,7 @@ resource "polytomic_redshift_connection" "redshift" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/s3_connection.md
+++ b/docs/resources/s3_connection.md
@@ -34,6 +34,7 @@ resource "polytomic_s3_connection" "s3" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/segment_connection.md
+++ b/docs/resources/segment_connection.md
@@ -31,6 +31,7 @@ resource "polytomic_segment_connection" "segment" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/snowflake_connection.md
+++ b/docs/resources/snowflake_connection.md
@@ -35,6 +35,7 @@ resource "polytomic_snowflake_connection" "snowflake" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/sqlserver_connection.md
+++ b/docs/resources/sqlserver_connection.md
@@ -36,6 +36,7 @@ resource "polytomic_sqlserver_connection" "sqlserver" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/statsig_connection.md
+++ b/docs/resources/statsig_connection.md
@@ -31,6 +31,7 @@ resource "polytomic_statsig_connection" "statsig" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/stripe_connection.md
+++ b/docs/resources/stripe_connection.md
@@ -31,6 +31,7 @@ resource "polytomic_stripe_connection" "stripe" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/survicate_connection.md
+++ b/docs/resources/survicate_connection.md
@@ -31,6 +31,7 @@ resource "polytomic_survicate_connection" "survicate" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/synapse_connection.md
+++ b/docs/resources/synapse_connection.md
@@ -35,6 +35,7 @@ resource "polytomic_synapse_connection" "synapse" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/uservoice_connection.md
+++ b/docs/resources/uservoice_connection.md
@@ -32,6 +32,7 @@ resource "polytomic_uservoice_connection" "uservoice" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/vanilla_connection.md
+++ b/docs/resources/vanilla_connection.md
@@ -32,6 +32,7 @@ resource "polytomic_vanilla_connection" "vanilla" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/docs/resources/webhook_connection.md
+++ b/docs/resources/webhook_connection.md
@@ -31,6 +31,7 @@ resource "polytomic_webhook_connection" "example" {
 
 ### Optional
 
+- `force_destroy` (Boolean) Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation.
 - `organization` (String) Organization ID
 
 ### Read-Only

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.28.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/polytomic/polytomic-go v0.0.0-20230804183226-a24c44fcef26
+	github.com/polytomic/polytomic-go v0.0.0-20230829135530-efa207431a84
 	github.com/rs/zerolog v1.30.0
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -276,6 +276,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polytomic/polytomic-go v0.0.0-20230804183226-a24c44fcef26 h1:3N3jPwo8iM9SneMbmLPeFv4SIft8hdT9YcEQ9q3NLgY=
 github.com/polytomic/polytomic-go v0.0.0-20230804183226-a24c44fcef26/go.mod h1:+XkC/jjW7clbyvuUrL973eCzno0HmGoYZO5qNMUNSfU=
+github.com/polytomic/polytomic-go v0.0.0-20230829135530-efa207431a84 h1:R7MWO1fxcGvkn8v7pWEATVRS8p7KbtwBQi85FmV9ops=
+github.com/polytomic/polytomic-go v0.0.0-20230829135530-efa207431a84/go.mod h1:+XkC/jjW7clbyvuUrL973eCzno0HmGoYZO5qNMUNSfU=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=

--- a/provider/connections_common.go
+++ b/provider/connections_common.go
@@ -14,6 +14,13 @@ var (
 	// ConnectionDatasourcesMap is a map of all the connections that can be
 	// imported as data sources.
 	ConnectionDatasourcesMap = datasourcesMap()
+
+	forceDestroyMessage = "Indicates whether dependent models, syncs, and bulk syncs should be cascade deleted when this connection is destroy. " +
+		"This only deletes other resources when the connection is destroyed, not when setting this parameter to `true`. " +
+		"Once this parameter is set to `true`, there must be a successful `terraform apply` run before a destroy is required to update this " +
+		"value in the resource state. Without a successful `terraform apply` after this parameter is set, this flag will have no effect. " +
+		"If setting this field in the same operation that would require replacing the connection or destroying the connection, this flag will not " +
+		"work. Additionally when importing a connection, a successful `terraform apply` is required to set this value in state before it will take effect on a destroy operation."
 )
 
 type connectionData struct {
@@ -21,6 +28,7 @@ type connectionData struct {
 	Name          types.String `tfsdk:"name"`
 	Id            types.String `tfsdk:"id"`
 	Configuration types.Object `tfsdk:"configuration"`
+	ForceDestroy  types.Bool   `tfsdk:"force_destroy"`
 }
 
 // connectionsMap combines the generated importable connections

--- a/provider/gen/connections/resource.go.tmpl
+++ b/provider/gen/connections/resource.go.tmpl
@@ -54,6 +54,10 @@ func (t *{{ .Connection }}ConnectionResource) Schema(ctx context.Context, req re
 				Type: types.ObjectType{},
 				{{ end }}
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "{{ .Name }} Connection identifier",
@@ -246,6 +250,21 @@ func (r *{{ .Connection }}ConnectionResource) Delete(ctx context.Context, req re
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_affinity_connection.go
+++ b/provider/resource_affinity_connection.go
@@ -49,6 +49,10 @@ func (t *AffinityConnectionResource) Schema(ctx context.Context, req resource.Sc
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Affinity Connection identifier",
@@ -221,6 +225,21 @@ func (r *AffinityConnectionResource) Delete(ctx context.Context, req resource.De
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_airtable_connection.go
+++ b/provider/resource_airtable_connection.go
@@ -49,6 +49,10 @@ func (t *AirtableConnectionResource) Schema(ctx context.Context, req resource.Sc
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Airtable Connection identifier",
@@ -221,6 +225,21 @@ func (r *AirtableConnectionResource) Delete(ctx context.Context, req resource.De
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_amplitude_connection.go
+++ b/provider/resource_amplitude_connection.go
@@ -55,6 +55,10 @@ func (t *AmplitudeConnectionResource) Schema(ctx context.Context, req resource.S
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Amplitude Connection identifier",
@@ -235,6 +239,21 @@ func (r *AmplitudeConnectionResource) Delete(ctx context.Context, req resource.D
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_asana_connection.go
+++ b/provider/resource_asana_connection.go
@@ -49,6 +49,10 @@ func (t *AsanaConnectionResource) Schema(ctx context.Context, req resource.Schem
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Asana Connection identifier",
@@ -221,6 +225,21 @@ func (r *AsanaConnectionResource) Delete(ctx context.Context, req resource.Delet
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_ascend_connection.go
+++ b/provider/resource_ascend_connection.go
@@ -49,6 +49,10 @@ func (t *AscendConnectionResource) Schema(ctx context.Context, req resource.Sche
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Ascend Connection identifier",
@@ -221,6 +225,21 @@ func (r *AscendConnectionResource) Delete(ctx context.Context, req resource.Dele
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_athena_connection.go
+++ b/provider/resource_athena_connection.go
@@ -67,6 +67,10 @@ func (t *AthenaConnectionResource) Schema(ctx context.Context, req resource.Sche
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "AWS Athena Connection identifier",
@@ -263,6 +267,21 @@ func (r *AthenaConnectionResource) Delete(ctx context.Context, req resource.Dele
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_azureblob_connection.go
+++ b/provider/resource_azureblob_connection.go
@@ -61,6 +61,10 @@ func (t *AzureblobConnectionResource) Schema(ctx context.Context, req resource.S
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Azure Blob Storage Connection identifier",
@@ -249,6 +253,21 @@ func (r *AzureblobConnectionResource) Delete(ctx context.Context, req resource.D
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_chargebee_connection.go
+++ b/provider/resource_chargebee_connection.go
@@ -61,6 +61,10 @@ func (t *ChargebeeConnectionResource) Schema(ctx context.Context, req resource.S
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Chargebee Connection identifier",
@@ -249,6 +253,21 @@ func (r *ChargebeeConnectionResource) Delete(ctx context.Context, req resource.D
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_cloudsql_connection.go
+++ b/provider/resource_cloudsql_connection.go
@@ -73,6 +73,10 @@ func (t *CloudsqlConnectionResource) Schema(ctx context.Context, req resource.Sc
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Cloud SQL Connection identifier",
@@ -277,6 +281,21 @@ func (r *CloudsqlConnectionResource) Delete(ctx context.Context, req resource.De
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_cosmosdb_connection.go
+++ b/provider/resource_cosmosdb_connection.go
@@ -55,6 +55,10 @@ func (t *CosmosdbConnectionResource) Schema(ctx context.Context, req resource.Sc
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Cosmos DB Connection identifier",
@@ -235,6 +239,21 @@ func (r *CosmosdbConnectionResource) Delete(ctx context.Context, req resource.De
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_csv_connection.go
+++ b/provider/resource_csv_connection.go
@@ -113,6 +113,10 @@ func (t *CSVConnectionResource) Schema(ctx context.Context, req resource.SchemaR
 				},
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "CSV Connection identifier",
@@ -304,8 +308,41 @@ func (r *CSVConnectionResource) Delete(ctx context.Context, req resource.DeleteR
 		return
 	}
 
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
+		return
+	}
+
 	err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()))
 	if err != nil {
+		pErr := polytomic.ApiError{}
+		if errors.As(err, &pErr) {
+			if pErr.StatusCode == http.StatusNotFound {
+				resp.State.RemoveResource(ctx)
+				return
+			}
+			if strings.Contains(pErr.Message, "connection in use") {
+				for _, meta := range pErr.Metadata {
+					info := meta.(map[string]interface{})
+					resp.Diagnostics.AddError("Connection in use",
+						fmt.Sprintf("Connection is used by %s \"%s\" (%s). Please remove before deleting this connection.",
+							info["type"], info["name"], info["id"]),
+					)
+				}
+				return
+			}
+		}
+
 		resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
 		return
 	}

--- a/provider/resource_customerio_connection.go
+++ b/provider/resource_customerio_connection.go
@@ -61,6 +61,10 @@ func (t *CustomerioConnectionResource) Schema(ctx context.Context, req resource.
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Customer.io Connection identifier",
@@ -249,6 +253,21 @@ func (r *CustomerioConnectionResource) Delete(ctx context.Context, req resource.
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_delighted_connection.go
+++ b/provider/resource_delighted_connection.go
@@ -49,6 +49,10 @@ func (t *DelightedConnectionResource) Schema(ctx context.Context, req resource.S
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Delighted Connection identifier",
@@ -221,6 +225,21 @@ func (r *DelightedConnectionResource) Delete(ctx context.Context, req resource.D
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_dialpad_connection.go
+++ b/provider/resource_dialpad_connection.go
@@ -49,6 +49,10 @@ func (t *DialpadConnectionResource) Schema(ctx context.Context, req resource.Sch
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Dialpad Connection identifier",
@@ -221,6 +225,21 @@ func (r *DialpadConnectionResource) Delete(ctx context.Context, req resource.Del
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_dynamodb_connection.go
+++ b/provider/resource_dynamodb_connection.go
@@ -61,6 +61,10 @@ func (t *DynamodbConnectionResource) Schema(ctx context.Context, req resource.Sc
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "DynamoDB Connection identifier",
@@ -249,6 +253,21 @@ func (r *DynamodbConnectionResource) Delete(ctx context.Context, req resource.De
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_freshdesk_connection.go
+++ b/provider/resource_freshdesk_connection.go
@@ -55,6 +55,10 @@ func (t *FreshdeskConnectionResource) Schema(ctx context.Context, req resource.S
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Freshdesk Connection identifier",
@@ -235,6 +239,21 @@ func (r *FreshdeskConnectionResource) Delete(ctx context.Context, req resource.D
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_fullstory_connection.go
+++ b/provider/resource_fullstory_connection.go
@@ -49,6 +49,10 @@ func (t *FullstoryConnectionResource) Schema(ctx context.Context, req resource.S
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "FullStory Connection identifier",
@@ -221,6 +225,21 @@ func (r *FullstoryConnectionResource) Delete(ctx context.Context, req resource.D
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_gcs_connection.go
+++ b/provider/resource_gcs_connection.go
@@ -61,6 +61,10 @@ func (t *GcsConnectionResource) Schema(ctx context.Context, req resource.SchemaR
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Google Cloud Storage Connection identifier",
@@ -249,6 +253,21 @@ func (r *GcsConnectionResource) Delete(ctx context.Context, req resource.DeleteR
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_harmonic_connection.go
+++ b/provider/resource_harmonic_connection.go
@@ -49,6 +49,10 @@ func (t *HarmonicConnectionResource) Schema(ctx context.Context, req resource.Sc
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Harmonic Connection identifier",
@@ -221,6 +225,21 @@ func (r *HarmonicConnectionResource) Delete(ctx context.Context, req resource.De
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_jira_connection.go
+++ b/provider/resource_jira_connection.go
@@ -73,6 +73,10 @@ func (t *JiraConnectionResource) Schema(ctx context.Context, req resource.Schema
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Jira Connection identifier",
@@ -277,6 +281,21 @@ func (r *JiraConnectionResource) Delete(ctx context.Context, req resource.Delete
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_klaviyo_connection.go
+++ b/provider/resource_klaviyo_connection.go
@@ -49,6 +49,10 @@ func (t *KlaviyoConnectionResource) Schema(ctx context.Context, req resource.Sch
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Klaviyo Connection identifier",
@@ -221,6 +225,21 @@ func (r *KlaviyoConnectionResource) Delete(ctx context.Context, req resource.Del
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_kustomer_connection.go
+++ b/provider/resource_kustomer_connection.go
@@ -55,6 +55,10 @@ func (t *KustomerConnectionResource) Schema(ctx context.Context, req resource.Sc
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Kustomer Connection identifier",
@@ -235,6 +239,21 @@ func (r *KustomerConnectionResource) Delete(ctx context.Context, req resource.De
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_linear_connection.go
+++ b/provider/resource_linear_connection.go
@@ -49,6 +49,10 @@ func (t *LinearConnectionResource) Schema(ctx context.Context, req resource.Sche
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Linear Connection identifier",
@@ -221,6 +225,21 @@ func (r *LinearConnectionResource) Delete(ctx context.Context, req resource.Dele
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_lob_connection.go
+++ b/provider/resource_lob_connection.go
@@ -49,6 +49,10 @@ func (t *LobConnectionResource) Schema(ctx context.Context, req resource.SchemaR
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Lob Connection identifier",
@@ -221,6 +225,21 @@ func (r *LobConnectionResource) Delete(ctx context.Context, req resource.DeleteR
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_marketo_connection.go
+++ b/provider/resource_marketo_connection.go
@@ -79,6 +79,10 @@ func (t *MarketoConnectionResource) Schema(ctx context.Context, req resource.Sch
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Marketo Connection identifier",
@@ -291,6 +295,21 @@ func (r *MarketoConnectionResource) Delete(ctx context.Context, req resource.Del
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_mongodb_connection.go
+++ b/provider/resource_mongodb_connection.go
@@ -79,6 +79,10 @@ func (t *MongodbConnectionResource) Schema(ctx context.Context, req resource.Sch
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "MongoDB Connection identifier",
@@ -291,6 +295,21 @@ func (r *MongodbConnectionResource) Delete(ctx context.Context, req resource.Del
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_mysql_connection.go
+++ b/provider/resource_mysql_connection.go
@@ -109,6 +109,10 @@ func (t *MysqlConnectionResource) Schema(ctx context.Context, req resource.Schem
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "MySQL Connection identifier",
@@ -361,6 +365,21 @@ func (r *MysqlConnectionResource) Delete(ctx context.Context, req resource.Delet
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_netsuite_connection.go
+++ b/provider/resource_netsuite_connection.go
@@ -73,6 +73,10 @@ func (t *NetsuiteConnectionResource) Schema(ctx context.Context, req resource.Sc
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "NetSuite Connection identifier",
@@ -277,6 +281,21 @@ func (r *NetsuiteConnectionResource) Delete(ctx context.Context, req resource.De
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_pipedrive_connection.go
+++ b/provider/resource_pipedrive_connection.go
@@ -55,6 +55,10 @@ func (t *PipedriveConnectionResource) Schema(ctx context.Context, req resource.S
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Pipedrive Connection identifier",
@@ -235,6 +239,21 @@ func (r *PipedriveConnectionResource) Delete(ctx context.Context, req resource.D
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_postgresql_connection.go
+++ b/provider/resource_postgresql_connection.go
@@ -145,6 +145,10 @@ func (t *PostgresqlConnectionResource) Schema(ctx context.Context, req resource.
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "PostgresSQL Connection identifier",
@@ -445,6 +449,21 @@ func (r *PostgresqlConnectionResource) Delete(ctx context.Context, req resource.
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_redshift_connection.go
+++ b/provider/resource_redshift_connection.go
@@ -127,6 +127,10 @@ func (t *RedshiftConnectionResource) Schema(ctx context.Context, req resource.Sc
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Redshift Connection identifier",
@@ -403,6 +407,21 @@ func (r *RedshiftConnectionResource) Delete(ctx context.Context, req resource.De
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_s3_connection.go
+++ b/provider/resource_s3_connection.go
@@ -67,6 +67,10 @@ func (t *S3ConnectionResource) Schema(ctx context.Context, req resource.SchemaRe
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "S3 Connection identifier",
@@ -263,6 +267,21 @@ func (r *S3ConnectionResource) Delete(ctx context.Context, req resource.DeleteRe
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_segment_connection.go
+++ b/provider/resource_segment_connection.go
@@ -49,6 +49,10 @@ func (t *SegmentConnectionResource) Schema(ctx context.Context, req resource.Sch
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Segment Connection identifier",
@@ -221,6 +225,21 @@ func (r *SegmentConnectionResource) Delete(ctx context.Context, req resource.Del
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_snowflake_connection.go
+++ b/provider/resource_snowflake_connection.go
@@ -79,6 +79,10 @@ func (t *SnowflakeConnectionResource) Schema(ctx context.Context, req resource.S
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Snowflake Connection identifier",
@@ -291,6 +295,21 @@ func (r *SnowflakeConnectionResource) Delete(ctx context.Context, req resource.D
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_sqlserver_connection.go
+++ b/provider/resource_sqlserver_connection.go
@@ -79,6 +79,10 @@ func (t *SqlserverConnectionResource) Schema(ctx context.Context, req resource.S
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "SQL Server Connection identifier",
@@ -291,6 +295,21 @@ func (r *SqlserverConnectionResource) Delete(ctx context.Context, req resource.D
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_statsig_connection.go
+++ b/provider/resource_statsig_connection.go
@@ -49,6 +49,10 @@ func (t *StatsigConnectionResource) Schema(ctx context.Context, req resource.Sch
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Statsig Connection identifier",
@@ -221,6 +225,21 @@ func (r *StatsigConnectionResource) Delete(ctx context.Context, req resource.Del
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_stripe_connection.go
+++ b/provider/resource_stripe_connection.go
@@ -49,6 +49,10 @@ func (t *StripeConnectionResource) Schema(ctx context.Context, req resource.Sche
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Stripe Connection identifier",
@@ -221,6 +225,21 @@ func (r *StripeConnectionResource) Delete(ctx context.Context, req resource.Dele
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_synapse_connection.go
+++ b/provider/resource_synapse_connection.go
@@ -73,6 +73,10 @@ func (t *SynapseConnectionResource) Schema(ctx context.Context, req resource.Sch
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Synapse Connection identifier",
@@ -277,6 +281,21 @@ func (r *SynapseConnectionResource) Delete(ctx context.Context, req resource.Del
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_uservoice_connection.go
+++ b/provider/resource_uservoice_connection.go
@@ -55,6 +55,10 @@ func (t *UservoiceConnectionResource) Schema(ctx context.Context, req resource.S
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "UserVoice Connection identifier",
@@ -235,6 +239,21 @@ func (r *UservoiceConnectionResource) Delete(ctx context.Context, req resource.D
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_vanilla_connection.go
+++ b/provider/resource_vanilla_connection.go
@@ -55,6 +55,10 @@ func (t *VanillaConnectionResource) Schema(ctx context.Context, req resource.Sch
 
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Vanilla Forums Connection identifier",
@@ -235,6 +239,21 @@ func (r *VanillaConnectionResource) Delete(ctx context.Context, req resource.Del
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
 		return
 	}
 

--- a/provider/resource_webhook_connection.go
+++ b/provider/resource_webhook_connection.go
@@ -61,6 +61,10 @@ func (t *WebhookConnectionResource) Schema(ctx context.Context, req resource.Sch
 				},
 				Required: true,
 			},
+			"force_destroy": schema.BoolAttribute{
+				MarkdownDescription: forceDestroyMessage,
+				Optional:            true,
+			},
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Webhook Connection identifier",
 				Computed:            true,
@@ -216,8 +220,41 @@ func (r *WebhookConnectionResource) Delete(ctx context.Context, req resource.Del
 		return
 	}
 
+	if data.ForceDestroy.ValueBool() {
+		err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()), polytomic.WithForceDelete())
+		if err != nil {
+			pErr := polytomic.ApiError{}
+			if errors.As(err, &pErr) {
+				if pErr.StatusCode == http.StatusNotFound {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+			resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
+		}
+		return
+	}
+
 	err := r.client.Connections().Delete(ctx, uuid.MustParse(data.Id.ValueString()))
 	if err != nil {
+		pErr := polytomic.ApiError{}
+		if errors.As(err, &pErr) {
+			if pErr.StatusCode == http.StatusNotFound {
+				resp.State.RemoveResource(ctx)
+				return
+			}
+			if strings.Contains(pErr.Message, "connection in use") {
+				for _, meta := range pErr.Metadata {
+					info := meta.(map[string]interface{})
+					resp.Diagnostics.AddError("Connection in use",
+						fmt.Sprintf("Connection is used by %s \"%s\" (%s). Please remove before deleting this connection.",
+							info["type"], info["name"], info["id"]),
+					)
+				}
+				return
+			}
+		}
+
 		resp.Diagnostics.AddError(clientError, fmt.Sprintf("Error deleting connection: %s", err))
 		return
 	}


### PR DESCRIPTION
This PR adds the option to cascade delete connections on a per-resource basis. This takes inspiration from the AWS provider where some resources have a `force_destroy` attribute. This also adds a `force_destroy` attribute to our connection resources which when set to `true` will cascade delete dependent resources.

I think it's also worth noting that since our terraform generator is now using referential id rather than literal ids, terraform also does a pretty good job at constructing the dependency graph and doing the right thing (i.e. deleting dependent resources).