### PR TITLE
Refactor partner, deployment key auth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,222 @@
+# AGENTS.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+This is the Terraform provider for Polytomic, enabling infrastructure-as-code
+management of Polytomic resources like connections, models, syncs, and policies.
+The provider supports 100+ connection types through code generation.
+
+## Key Commands
+
+### Development
+
+```bash
+# Full development setup (installs provider, generates code, builds docs)
+make dev
+
+# Build and install provider locally
+go install
+
+# Generate connection code from templates
+go generate
+
+# Run unit tests
+go test ./...
+
+# Run acceptance tests (requires POLYTOMIC_API_KEY)
+TF_ACC=1 go test ./... -v
+
+# Generate documentation
+go generate
+
+# Format code
+go fmt ./...
+```
+
+### Local Testing
+
+1. Create a `.tfrc` file pointing to local provider:
+
+```hcl
+provider_installation {
+  dev_overrides {
+    "polytomic/polytomic" = "/Users/[username]/go/bin"
+  }
+  direct {}
+}
+```
+
+2. Set environment: `export TF_CLI_CONFIG_FILE=.tfrc`
+3. Provider will use version "99.0.0" for local development
+
+## Architecture
+
+### Directory Structure
+
+- `/provider` - Core provider implementation
+  - `/resource_*.go` - Resource implementations (connections, models, syncs, etc.)
+  - `/data_source_*.go` - Data source implementations
+  - `/gen/` - Code generation logic for connection types
+  - `/internal/` - Generated connection implementations
+  - `/client.go` - Polytomic API client wrapper
+  - `/validators/` - Custom validators for provider configuration
+- `/importer` - CLI tool for importing existing Polytomic configurations
+  - `/main.go` - CLI entry point and provider template generation
+  - `/import.go` - Core import orchestration and variable handling
+  - `/connections.go` - Connection resource/datasource import logic
+  - `/models.go`, `/syncs.go`, `/bulk_syncs.go` - Resource-specific importers
+  - `/policy.go`, `/role.go` - Permission resource importers (optional)
+  - `/variables.go` - Terraform variable generation utilities
+  - `/formatter.go` - HCL formatting and variable reference handling
+- `/hack` - Development scripts
+- `/docs` - Auto-generated documentation
+- `/examples` - Usage examples
+
+### Code Generation Pattern
+
+The provider uses extensive code generation for connection types:
+
+1. Templates in `/provider/gen/internal/templates/`
+2. Generator code in `/provider/gen/internal/generator/`
+3. Connection definitions loaded from Polytomic API
+4. Generated files in `/provider/internal/`
+5. Run `go generate` to regenerate
+
+### Authentication
+
+Provider supports three authentication methods (in order of precedence):
+
+1. Deployment key (for globa access; may be specified with an organization ID)
+2. Partner key (for partner access; may be specified with an organization ID)
+3. API key (standard organization access)
+
+Configuration via environment variables or provider block:
+
+```hcl
+provider "polytomic" {
+  deployment_key = "..."
+  # OR
+  partner_key = "..."
+  account_id = "..."
+  # OR
+  api_key = "..."
+}
+```
+
+### Resource Patterns
+
+All resources follow standard Terraform CRUD patterns:
+
+- Create: `resource<Type>Create()`
+- Read: `resource<Type>Read()`
+- Update: `resource<Type>Update()`
+- Delete: `resource<Type>Delete()`
+
+Resources use Terraform Plugin Framework with typed models.
+
+### Testing Approach
+
+- Unit tests: Standard Go tests in `*_test.go` files
+- Acceptance tests: Real API tests with `TF_ACC=1`
+- CI/CD: GitHub Actions on push and PR
+- Local provider override via `.tfrc` for manual testing
+
+## Common Tasks
+
+### Adding a New Resource
+
+1. Create `provider/resource_<name>.go`
+2. Implement CRUD functions following existing patterns
+3. Add to provider schema in `provider/provider.go`
+4. Create acceptance test in `provider/resource_<name>_test.go`
+5. Run `go generate` to update docs
+6. Add example in `examples/resources/<name>/`
+
+### Updating Connection Types
+
+1. Connection definitions are fetched from Polytomic API
+2. Modify generator code if needed in `/provider/gen/`
+3. Run `go generate` to regenerate
+4. Test with acceptance tests
+
+### Working with the Importer
+
+1. **Adding New Resource Types**:
+
+   - Create new importer component implementing `Importable` interface
+   - Add to `importables` slice in `import.go`
+   - Handle organization tracking with `OrganizationTracker` if applicable
+
+2. **Testing Importer Changes**:
+
+   - Build importer: `go build -o importer ./importer`
+   - Run with test API key: `./importer run --api-key $API_KEY --output test-import`
+   - Check generated `.tf` files and `variables.tf`
+
+3. **Variable Generation Patterns**:
+   - Use centralized collection in `import.go` for shared variables
+   - Implement `OrganizationTracker` interface for organization-aware components
+   - Use `unquoteVariableRef()` for variable references in HCL output
+
+### Debugging
+
+- Enable debug logs: `TF_LOG=DEBUG terraform apply`
+- API client logs requests/responses with debug logging
+- Use `tflog` package for structured logging in provider code
+
+## Release Process
+
+1. Update CHANGELOG.md
+2. Create and push git tag: `git tag v1.0.0 && git push origin v1.0.0`
+3. GitHub Actions automatically builds and publishes to Terraform Registry
+
+## Importer Architecture
+
+### Component Pattern
+
+The importer uses a modular architecture with the `Importable` interface:
+
+```go
+type Importable interface {
+    Init(ctx context.Context) error
+    ResourceRefs() map[string]string
+    DatasourceRefs() map[string]string
+    GenerateTerraformFiles(ctx context.Context, writer io.Writer, refs map[string]string) error
+    GenerateImports(ctx context.Context, writer io.Writer) error
+    Filename() string
+    Variables() []Variable
+}
+```
+
+### Organization Variable Pattern
+
+The importer generates reusable variables for commonly referenced values:
+
+- **Single Organization**: When all resources belong to one organization, creates `var.polytomic_organization_id`
+- **Variable References**: Uses `unquoteVariableRef()` to convert quoted variable strings to actual variable references
+- **Centralized Collection**: `OrganizationTracker` interface allows components to report organization IDs
+- **Two-Pass Processing**: First pass collects metadata, second pass generates files with proper variable references
+
+### HCL Generation
+
+- Uses `hclwrite` package for programmatic HCL generation
+- `typeConverter()` handles arbitrary value to `cty.Value` conversion
+- `unquoteVariableRef()` post-processes HCL to convert `"var.name"` to `var.name`
+- Variable references enable more maintainable generated code
+
+### Authentication Context
+
+- Single organization API key: Generates organization variable with default value
+- Multi-organization scenarios: Falls back to hard-coded organization IDs
+- Currently supports API key authentication only (not deployment keys)
+
+## Important Notes
+
+- Provider uses a fork of terraform-plugin-framework (see go.mod)
+- All API operations use the Polytomic Go SDK
+- Resource imports supported via `terraform import`
+- Sensitive values (API keys, secrets) marked with `Sensitive: true`
+- Connection configurations stored as JSON strings in state
+- Importer generates variables for reusable values (organization IDs, etc.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,11 +1,12 @@
 POLYTOMIC_DEPLOYMENT_URL ?= https://app.polytomic-local.com:8443
+TESTARGS ?= -count=1
 
 default: testacc
 
 # Run acceptance tests
 .PHONY: testacc
 testacc:
-	POLYTOMIC_DEPLOYMENT_URL=$(POLYTOMIC_DEPLOYMENT_URL) TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
+	POLYTOMIC_DEPLOYMENT_URL=$(POLYTOMIC_DEPLOYMENT_URL) TF_ACC=1 go test ./... $(TESTARGS) -timeout 120m
 
 
 .PHONY: dev

--- a/docs/data-sources/bulk_source.md
+++ b/docs/data-sources/bulk_source.md
@@ -25,9 +25,12 @@ data "polytomic_bulk_source" "source" {
 
 - `connection_id` (String)
 
+### Optional
+
+- `organization` (String) The organization to which the connection belongs. This is required when using a partner or deployment key.
+
 ### Read-Only
 
-- `organization` (String)
 - `schemas` (List of Object) (see [below for nested schema](#nestedatt--schemas))
 
 <a id="nestedatt--schemas"></a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,13 +29,11 @@ provider "polytomic" {
 ```terraform
 provider "polytomic" {
   partner_key = "<value from settings page>"
-  organization_user = "terraform@polytomic.com"
 }
 ```
 
-The `organization_user` may be any valid email address. When using a partner key
-to access resources in an organization the user with this email address will be
-used. The user will be created in the organization if it does not exist.
+When accessing organization specific resources using a Partner key, the
+`organization` must be specified.
 
 ### Deployment API Key (On-Premises only)
 
@@ -54,7 +52,6 @@ provider "polytomic" {
 - `api_key` (String, Sensitive) Polytomic API key
 - `deployment_api_key` (String, Sensitive) Polytomic deployment key
 - `deployment_url` (String) Polytomic deployment URL (defaults to app.polytomic.com)
-- `organization_user` (String) Polytomic organization user; required if `partner_key` is set.
 - `partner_key` (String, Sensitive) Polytomic partner key
 
 

--- a/provider/datasource_bulk_source.go
+++ b/provider/datasource_bulk_source.go
@@ -41,7 +41,8 @@ func (d *bulkSourceDatasource) Schema(ctx context.Context, req datasource.Schema
 			},
 			"organization": schema.StringAttribute{
 				MarkdownDescription: "",
-				Computed:            true,
+				Optional:            true,
+				Description:         "The organization to which the connection belongs. This is required when using a partner or deployment key.",
 			},
 			"schemas": schema.ListAttribute{
 				MarkdownDescription: "",

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -42,8 +42,7 @@ type ProviderData struct {
 	DeploymentKey types.String `tfsdk:"deployment_api_key"`
 	DeploymentUrl types.String `tfsdk:"deployment_url"`
 
-	PartnerKey       types.String `tfsdk:"partner_key"`
-	OrganizationUser types.String `tfsdk:"organization_user"`
+	PartnerKey types.String `tfsdk:"partner_key"`
 
 	APIKey types.String `tfsdk:"api_key"`
 }
@@ -72,10 +71,6 @@ func (p *Provider) ConfigValidators(context.Context) []provider.ConfigValidator 
 		providervalidator.RequiredTogether(
 			path.MatchRoot("deployment_api_key"),
 			path.MatchRoot("deployment_url"),
-		),
-		providervalidator.RequiredTogether(
-			path.MatchRoot("partner_key"),
-			path.MatchRoot("organization_user"),
 		),
 	}
 }
@@ -113,7 +108,7 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 				os.Getenv(PolytomicDeploymentKey),
 			),
 		),
-		providerclient.WithPartnerKey(data.PartnerKey.ValueString(), data.OrganizationUser.ValueString()),
+		providerclient.WithPartnerKey(data.PartnerKey.ValueString()),
 		providerclient.WithAPIKey(
 			cmp.Or(
 				data.APIKey.ValueString(),
@@ -177,11 +172,6 @@ func (p *Provider) Schema(ctx context.Context, req provider.SchemaRequest, resp 
 				MarkdownDescription: "Polytomic partner key",
 				Optional:            true,
 				Sensitive:           true,
-			},
-			"organization_user": schema.StringAttribute{
-				MarkdownDescription: "Polytomic organization user; required if `partner_key` is set.",
-				Optional:            true,
-				Sensitive:           false,
 			},
 		},
 	}

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -33,14 +33,21 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
-func testClient(t *testing.T) *ptclient.Client {
+func testClient(t *testing.T, org string) *ptclient.Client {
+	t.Helper()
+
 	provider, err := providerclient.NewClientProvider(
 		providerclient.WithDeploymentKey(os.Getenv(PolytomicDeploymentKey)),
 		providerclient.WithDeploymentURL(os.Getenv(PolytomicDeploymentURL)),
 		providerclient.WithAPIKey(os.Getenv(PolytomicAPIKey)),
 	)
 	require.NoError(t, err)
-	c, err := provider.Client("")
+	if org == "" {
+		c, err := provider.PartnerClient()
+		require.NoError(t, err)
+		return c
+	}
+	c, err := provider.Client(org)
 	require.NoError(t, err)
 	return c
 }

--- a/provider/resource_organization_test.go
+++ b/provider/resource_organization_test.go
@@ -1,0 +1,77 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/AlekSi/pointer"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccOrganization_basic(t *testing.T) {
+	if os.Getenv("TEST_ORG_RESOURCES") != "true" {
+		t.Skip("Skipping test that creates resources in the Terraform test organization. To run, set TEST_ORG_RESOURCES=true")
+	}
+
+	orgName := "terraform-test-org"
+	orgName2 := "terraform-test-org-updated"
+	ssoDomain := "acmeinc.com"
+	ssoOrgId := "org_123456"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOrganizationResource(orgName, ssoDomain, ssoOrgId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccOrganizationExists(t, orgName),
+					resource.TestCheckResourceAttr("polytomic_organization.test", "name", orgName),
+					resource.TestCheckResourceAttr("polytomic_organization.test", "sso_domain", ssoDomain),
+					resource.TestCheckResourceAttr("polytomic_organization.test", "sso_org_id", ssoOrgId),
+				),
+			},
+			{
+				Config: testAccOrganizationResource(orgName2, ssoDomain, ssoOrgId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccOrganizationExists(t, orgName2),
+					resource.TestCheckResourceAttr("polytomic_organization.test", "name", orgName2),
+				),
+			},
+		},
+	})
+}
+
+func testAccOrganizationExists(t *testing.T, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources["polytomic_organization.test"]
+		if !ok {
+			return fmt.Errorf("not found: %s", "polytomic_organization.test")
+		}
+		if rs.Primary.Attributes["name"] != name {
+			return fmt.Errorf("name is %s; want %s", rs.Primary.Attributes["name"], name)
+		}
+
+		client := testClient(t, "")
+		organization, err := client.Organization.Get(t.Context(), rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if pointer.Get(organization.Data.Name) != name {
+			return fmt.Errorf("organization name is %s; want %s", pointer.Get(organization.Data.Name), name)
+		}
+		return nil
+	}
+}
+
+func testAccOrganizationResource(name, ssoDomain, ssoOrgId string) string {
+	return fmt.Sprintf(`
+resource "polytomic_organization" "test" {
+	name       = "%s"
+	sso_domain = "%s"
+	sso_org_id = "%s"
+}
+`, name, ssoDomain, ssoOrgId)
+}

--- a/provider/resource_user_test.go
+++ b/provider/resource_user_test.go
@@ -3,8 +3,10 @@ package provider
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/AlekSi/pointer"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
@@ -27,21 +29,26 @@ func TestAccUser_basic(t *testing.T) {
 			{
 				Config: testAccUserResource(email, role, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccUserExists(email),
+					testAccUserExists(t, email),
 				),
 			},
 			{
 				Config: testAccUserResource(email2, role, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccUserExists(email2),
+					testAccUserExists(t, email2),
 				),
 			},
 		},
 	})
 }
 
-func testAccUserExists(email string) resource.TestCheckFunc {
+func testAccUserExists(t *testing.T, email string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		org, ok := s.RootModule().Resources["polytomic_organization.acme"]
+		if !ok {
+			return fmt.Errorf("not found: %s", "polytomic_organization.acme")
+		}
+
 		rs, ok := s.RootModule().Resources["polytomic_user.admin"]
 		if !ok {
 			return fmt.Errorf("not found: %s", "polytomic_user.admin")
@@ -49,8 +56,23 @@ func testAccUserExists(email string) resource.TestCheckFunc {
 		if rs.Primary.Attributes["email"] != email {
 			return fmt.Errorf("email is %s; want %s", rs.Primary.Attributes["email"], email)
 		}
-		return nil
 
+		client := testClient(t, "")
+		users, err := client.Users.List(t.Context(), org.Primary.ID)
+		if err != nil {
+			return err
+		}
+		var found bool
+		for _, user := range users.Data {
+			if strings.EqualFold(pointer.Get(user.Email), email) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("user %s not found in API response", email)
+		}
+		return nil
 	}
 }
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -29,13 +29,11 @@ provider "polytomic" {
 ```terraform
 provider "polytomic" {
   partner_key = "<value from settings page>"
-  organization_user = "terraform@polytomic.com"
 }
 ```
 
-The `organization_user` may be any valid email address. When using a partner key
-to access resources in an organization the user with this email address will be
-used. The user will be created in the organization if it does not exist.
+When accessing organization specific resources using a Partner key, the
+`organization` must be specified.
 
 ### Deployment API Key (On-Premises only)
 


### PR DESCRIPTION
This commit updates the Provider to avoid the need for an organization user when operating with a partner or deployment key.