### PR TITLE
Preserve sensitive values across Create and Update

### DIFF
--- a/provider/gen/connections/resource.go.tmpl
+++ b/provider/gen/connections/resource.go.tmpl
@@ -194,6 +194,23 @@ func (r *{{ .Connection }}ConnectionResource) Create(ctx context.Context, req re
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	{{ if .Attributes -}}
+	configAttributes, ok := getConfigAttributes({{ .Connection }}Schema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
+	{{ end -}}
 
 	conf := {{ .Connection }}Conf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
@@ -334,6 +351,18 @@ func (r *{{ .Connection }}ConnectionResource) Update(ctx context.Context, req re
 	data.Id = types.StringPointerValue(updated.Data.Id)
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
+
+	{{ if .Attributes -}}
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
+	{{ end -}}
 
 	conf := {{ .Connection }}Conf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)

--- a/provider/internal/connections/common.go
+++ b/provider/internal/connections/common.go
@@ -145,7 +145,10 @@ func attrValue(ctx context.Context, val attr.Value) (interface{}, error) {
 // used to wipe whatever is read from the api back to its original state
 func resetSensitiveValues(attrs map[string]schema.Attribute, state, read map[string]any) map[string]any {
 	for k, attr := range attrs {
-		if attr.IsSensitive() {
+		// Preserve server-managed computed-only sensitive values from the API
+		// response. Restore all other sensitive values from state so Terraform
+		// does not see masked API values as drift.
+		if attr.IsSensitive() && !(attr.IsComputed() && !attr.IsRequired() && !attr.IsOptional()) {
 			read[k] = state[k]
 			continue
 		}

--- a/provider/internal/connections/common_test.go
+++ b/provider/internal/connections/common_test.go
@@ -586,6 +586,40 @@ func TestResetSensitiveValues(t *testing.T) {
 				},
 			},
 		},
+		"computed-only sensitive value is preserved": {
+			attrs: map[string]schema.Attribute{
+				"secret": schema.StringAttribute{
+					Computed:  true,
+					Sensitive: true,
+				},
+			},
+			state: map[string]any{
+				"secret": "",
+			},
+			read: map[string]any{
+				"secret": "server-generated-secret",
+			},
+			expected: map[string]any{
+				"secret": "server-generated-secret",
+			},
+		},
+		"optional sensitive value is restored": {
+			attrs: map[string]schema.Attribute{
+				"api_key": schema.StringAttribute{
+					Optional:  true,
+					Sensitive: true,
+				},
+			},
+			state: map[string]any{
+				"api_key": "configured-secret",
+			},
+			read: map[string]any{
+				"api_key": "********",
+			},
+			expected: map[string]any{
+				"api_key": "configured-secret",
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/provider/internal/connections/resource_affinity_connection.go
+++ b/provider/internal/connections/resource_affinity_connection.go
@@ -151,6 +151,21 @@ func (r *AffinityConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(AffinitySchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := AffinityConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -297,6 +312,15 @@ func (r *AffinityConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := AffinityConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_airtable_connection.go
+++ b/provider/internal/connections/resource_airtable_connection.go
@@ -195,6 +195,21 @@ func (r *AirtableConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(AirtableSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := AirtableConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -349,6 +364,15 @@ func (r *AirtableConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := AirtableConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_amazon_selling_partner_connection.go
+++ b/provider/internal/connections/resource_amazon_selling_partner_connection.go
@@ -176,6 +176,21 @@ func (r *Amazon_selling_partnerConnectionResource) Create(ctx context.Context, r
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Amazon_selling_partnerSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Amazon_selling_partnerConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -326,6 +341,15 @@ func (r *Amazon_selling_partnerConnectionResource) Update(ctx context.Context, r
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Amazon_selling_partnerConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_amplemarket_connection.go
+++ b/provider/internal/connections/resource_amplemarket_connection.go
@@ -151,6 +151,21 @@ func (r *AmplemarketConnectionResource) Create(ctx context.Context, req resource
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(AmplemarketSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := AmplemarketConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -297,6 +312,15 @@ func (r *AmplemarketConnectionResource) Update(ctx context.Context, req resource
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := AmplemarketConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_amplitude_connection.go
+++ b/provider/internal/connections/resource_amplitude_connection.go
@@ -143,6 +143,21 @@ func (r *AmplitudeConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(AmplitudeSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := AmplitudeConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -287,6 +302,15 @@ func (r *AmplitudeConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := AmplitudeConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_api_connection.go
+++ b/provider/internal/connections/resource_api_connection.go
@@ -355,6 +355,21 @@ func (r *ApiConnectionResource) Create(ctx context.Context, req resource.CreateR
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(ApiSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := ApiConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -597,6 +612,15 @@ func (r *ApiConnectionResource) Update(ctx context.Context, req resource.UpdateR
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := ApiConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_apollo_connection.go
+++ b/provider/internal/connections/resource_apollo_connection.go
@@ -135,6 +135,21 @@ func (r *ApolloConnectionResource) Create(ctx context.Context, req resource.Crea
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(ApolloSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := ApolloConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *ApolloConnectionResource) Update(ctx context.Context, req resource.Upda
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := ApolloConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_appcues_connection.go
+++ b/provider/internal/connections/resource_appcues_connection.go
@@ -154,6 +154,21 @@ func (r *AppcuesConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(AppcuesSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := AppcuesConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -300,6 +315,15 @@ func (r *AppcuesConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := AppcuesConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_appsflyer_connection.go
+++ b/provider/internal/connections/resource_appsflyer_connection.go
@@ -143,6 +143,21 @@ func (r *AppsflyerConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(AppsflyerSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := AppsflyerConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -287,6 +302,15 @@ func (r *AppsflyerConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := AppsflyerConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_appstoreconnect_connection.go
+++ b/provider/internal/connections/resource_appstoreconnect_connection.go
@@ -159,6 +159,21 @@ func (r *AppstoreconnectConnectionResource) Create(ctx context.Context, req reso
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(AppstoreconnectSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := AppstoreconnectConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -307,6 +322,15 @@ func (r *AppstoreconnectConnectionResource) Update(ctx context.Context, req reso
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := AppstoreconnectConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_asana_connection.go
+++ b/provider/internal/connections/resource_asana_connection.go
@@ -157,6 +157,21 @@ func (r *AsanaConnectionResource) Create(ctx context.Context, req resource.Creat
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(AsanaSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := AsanaConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -303,6 +318,15 @@ func (r *AsanaConnectionResource) Update(ctx context.Context, req resource.Updat
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := AsanaConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_ascend_connection.go
+++ b/provider/internal/connections/resource_ascend_connection.go
@@ -135,6 +135,21 @@ func (r *AscendConnectionResource) Create(ctx context.Context, req resource.Crea
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(AscendSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := AscendConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *AscendConnectionResource) Update(ctx context.Context, req resource.Upda
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := AscendConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_ashby_connection.go
+++ b/provider/internal/connections/resource_ashby_connection.go
@@ -135,6 +135,21 @@ func (r *AshbyConnectionResource) Create(ctx context.Context, req resource.Creat
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(AshbySchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := AshbyConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *AshbyConnectionResource) Update(ctx context.Context, req resource.Updat
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := AshbyConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_attio_connection.go
+++ b/provider/internal/connections/resource_attio_connection.go
@@ -148,6 +148,21 @@ func (r *AttioConnectionResource) Create(ctx context.Context, req resource.Creat
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(AttioSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := AttioConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -294,6 +309,15 @@ func (r *AttioConnectionResource) Update(ctx context.Context, req resource.Updat
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := AttioConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_auth0_connection.go
+++ b/provider/internal/connections/resource_auth0_connection.go
@@ -151,6 +151,21 @@ func (r *Auth0ConnectionResource) Create(ctx context.Context, req resource.Creat
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Auth0Schema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Auth0Conf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -297,6 +312,15 @@ func (r *Auth0ConnectionResource) Update(ctx context.Context, req resource.Updat
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Auth0Conf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_autura_connection.go
+++ b/provider/internal/connections/resource_autura_connection.go
@@ -145,6 +145,21 @@ func (r *AuturaConnectionResource) Create(ctx context.Context, req resource.Crea
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(AuturaSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := AuturaConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -289,6 +304,15 @@ func (r *AuturaConnectionResource) Update(ctx context.Context, req resource.Upda
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := AuturaConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_awsathena_connection.go
+++ b/provider/internal/connections/resource_awsathena_connection.go
@@ -212,6 +212,21 @@ func (r *AwsathenaConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(AwsathenaSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := AwsathenaConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -374,6 +389,15 @@ func (r *AwsathenaConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := AwsathenaConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_awsopensearch_connection.go
+++ b/provider/internal/connections/resource_awsopensearch_connection.go
@@ -167,6 +167,21 @@ func (r *AwsopensearchConnectionResource) Create(ctx context.Context, req resour
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(AwsopensearchSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := AwsopensearchConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -317,6 +332,15 @@ func (r *AwsopensearchConnectionResource) Update(ctx context.Context, req resour
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := AwsopensearchConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_azureblob_connection.go
+++ b/provider/internal/connections/resource_azureblob_connection.go
@@ -280,6 +280,21 @@ func (r *AzureblobConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(AzureblobSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := AzureblobConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -456,6 +471,15 @@ func (r *AzureblobConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := AzureblobConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_azuresql_connection.go
+++ b/provider/internal/connections/resource_azuresql_connection.go
@@ -253,6 +253,21 @@ func (r *AzuresqlConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(AzuresqlSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := AzuresqlConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -423,6 +438,15 @@ func (r *AzuresqlConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := AzuresqlConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_barbourabi_connection.go
+++ b/provider/internal/connections/resource_barbourabi_connection.go
@@ -154,6 +154,21 @@ func (r *BarbourabiConnectionResource) Create(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(BarbourabiSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := BarbourabiConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -300,6 +315,15 @@ func (r *BarbourabiConnectionResource) Update(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := BarbourabiConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_bigquery_connection.go
+++ b/provider/internal/connections/resource_bigquery_connection.go
@@ -228,6 +228,21 @@ func (r *BigqueryConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(BigquerySchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := BigqueryConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -390,6 +405,15 @@ func (r *BigqueryConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := BigqueryConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_botpress_connection.go
+++ b/provider/internal/connections/resource_botpress_connection.go
@@ -143,6 +143,21 @@ func (r *BotpressConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(BotpressSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := BotpressConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -287,6 +302,15 @@ func (r *BotpressConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := BotpressConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_brevo_connection.go
+++ b/provider/internal/connections/resource_brevo_connection.go
@@ -135,6 +135,21 @@ func (r *BrevoConnectionResource) Create(ctx context.Context, req resource.Creat
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(BrevoSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := BrevoConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *BrevoConnectionResource) Update(ctx context.Context, req resource.Updat
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := BrevoConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_calendly_connection.go
+++ b/provider/internal/connections/resource_calendly_connection.go
@@ -135,6 +135,21 @@ func (r *CalendlyConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(CalendlySchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := CalendlyConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *CalendlyConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := CalendlyConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_callrail_connection.go
+++ b/provider/internal/connections/resource_callrail_connection.go
@@ -135,6 +135,21 @@ func (r *CallrailConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(CallrailSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := CallrailConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *CallrailConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := CallrailConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_campfire_connection.go
+++ b/provider/internal/connections/resource_campfire_connection.go
@@ -135,6 +135,21 @@ func (r *CampfireConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(CampfireSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := CampfireConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *CampfireConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := CampfireConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_chameleon_connection.go
+++ b/provider/internal/connections/resource_chameleon_connection.go
@@ -135,6 +135,21 @@ func (r *ChameleonConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(ChameleonSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := ChameleonConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *ChameleonConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := ChameleonConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_chargebee_connection.go
+++ b/provider/internal/connections/resource_chargebee_connection.go
@@ -169,6 +169,21 @@ func (r *ChargebeeConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(ChargebeeSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := ChargebeeConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -317,6 +332,15 @@ func (r *ChargebeeConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := ChargebeeConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_chili_piper_connection.go
+++ b/provider/internal/connections/resource_chili_piper_connection.go
@@ -135,6 +135,21 @@ func (r *Chili_piperConnectionResource) Create(ctx context.Context, req resource
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Chili_piperSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Chili_piperConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *Chili_piperConnectionResource) Update(ctx context.Context, req resource
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Chili_piperConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_chorus_connection.go
+++ b/provider/internal/connections/resource_chorus_connection.go
@@ -168,6 +168,21 @@ func (r *ChorusConnectionResource) Create(ctx context.Context, req resource.Crea
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(ChorusSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := ChorusConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -316,6 +331,15 @@ func (r *ChorusConnectionResource) Update(ctx context.Context, req resource.Upda
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := ChorusConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_circle_connection.go
+++ b/provider/internal/connections/resource_circle_connection.go
@@ -137,6 +137,21 @@ func (r *CircleConnectionResource) Create(ctx context.Context, req resource.Crea
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(CircleSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := CircleConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -279,6 +294,15 @@ func (r *CircleConnectionResource) Update(ctx context.Context, req resource.Upda
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := CircleConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_clari_connection.go
+++ b/provider/internal/connections/resource_clari_connection.go
@@ -146,6 +146,21 @@ func (r *ClariConnectionResource) Create(ctx context.Context, req resource.Creat
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(ClariSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := ClariConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -290,6 +305,15 @@ func (r *ClariConnectionResource) Update(ctx context.Context, req resource.Updat
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := ClariConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_clazar_connection.go
+++ b/provider/internal/connections/resource_clazar_connection.go
@@ -143,6 +143,21 @@ func (r *ClazarConnectionResource) Create(ctx context.Context, req resource.Crea
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(ClazarSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := ClazarConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -287,6 +302,15 @@ func (r *ClazarConnectionResource) Update(ctx context.Context, req resource.Upda
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := ClazarConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_clerk_connection.go
+++ b/provider/internal/connections/resource_clerk_connection.go
@@ -135,6 +135,21 @@ func (r *ClerkConnectionResource) Create(ctx context.Context, req resource.Creat
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(ClerkSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := ClerkConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *ClerkConnectionResource) Update(ctx context.Context, req resource.Updat
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := ClerkConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_clickhouse_connection.go
+++ b/provider/internal/connections/resource_clickhouse_connection.go
@@ -226,6 +226,21 @@ func (r *ClickhouseConnectionResource) Create(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(ClickhouseSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := ClickhouseConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -390,6 +405,15 @@ func (r *ClickhouseConnectionResource) Update(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := ClickhouseConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_cloudflare_logs_connection.go
+++ b/provider/internal/connections/resource_cloudflare_logs_connection.go
@@ -163,6 +163,21 @@ func (r *Cloudflare_logsConnectionResource) Create(ctx context.Context, req reso
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Cloudflare_logsSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Cloudflare_logsConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -311,6 +326,15 @@ func (r *Cloudflare_logsConnectionResource) Update(ctx context.Context, req reso
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Cloudflare_logsConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_cloudflare_r2_connection.go
+++ b/provider/internal/connections/resource_cloudflare_r2_connection.go
@@ -243,6 +243,21 @@ func (r *Cloudflare_r2ConnectionResource) Create(ctx context.Context, req resour
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Cloudflare_r2Schema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Cloudflare_r2Conf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -411,6 +426,15 @@ func (r *Cloudflare_r2ConnectionResource) Update(ctx context.Context, req resour
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Cloudflare_r2Conf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_construct_connect_connection.go
+++ b/provider/internal/connections/resource_construct_connect_connection.go
@@ -135,6 +135,21 @@ func (r *Construct_connectConnectionResource) Create(ctx context.Context, req re
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Construct_connectSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Construct_connectConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *Construct_connectConnectionResource) Update(ctx context.Context, req re
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Construct_connectConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_constructionwire_connection.go
+++ b/provider/internal/connections/resource_constructionwire_connection.go
@@ -143,6 +143,21 @@ func (r *ConstructionwireConnectionResource) Create(ctx context.Context, req res
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(ConstructionwireSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := ConstructionwireConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -287,6 +302,15 @@ func (r *ConstructionwireConnectionResource) Update(ctx context.Context, req res
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := ConstructionwireConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_cosmosdb_connection.go
+++ b/provider/internal/connections/resource_cosmosdb_connection.go
@@ -143,6 +143,21 @@ func (r *CosmosdbConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(CosmosdbSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := CosmosdbConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -287,6 +302,15 @@ func (r *CosmosdbConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := CosmosdbConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_csv_connection.go
+++ b/provider/internal/connections/resource_csv_connection.go
@@ -339,6 +339,21 @@ func (r *CsvConnectionResource) Create(ctx context.Context, req resource.CreateR
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(CsvSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := CsvConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -577,6 +592,15 @@ func (r *CsvConnectionResource) Update(ctx context.Context, req resource.UpdateR
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := CsvConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_customerio_connection.go
+++ b/provider/internal/connections/resource_customerio_connection.go
@@ -162,6 +162,21 @@ func (r *CustomerioConnectionResource) Create(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(CustomerioSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := CustomerioConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -310,6 +325,15 @@ func (r *CustomerioConnectionResource) Update(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := CustomerioConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_customeriowarehouseexports_connection.go
+++ b/provider/internal/connections/resource_customeriowarehouseexports_connection.go
@@ -205,6 +205,21 @@ func (r *CustomeriowarehouseexportsConnectionResource) Create(ctx context.Contex
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(CustomeriowarehouseexportsSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := CustomeriowarehouseexportsConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -361,6 +376,15 @@ func (r *CustomeriowarehouseexportsConnectionResource) Update(ctx context.Contex
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := CustomeriowarehouseexportsConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_databricks_connection.go
+++ b/provider/internal/connections/resource_databricks_connection.go
@@ -447,6 +447,21 @@ func (r *DatabricksConnectionResource) Create(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(DatabricksSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := DatabricksConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -657,6 +672,15 @@ func (r *DatabricksConnectionResource) Update(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := DatabricksConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_datadog_connection.go
+++ b/provider/internal/connections/resource_datadog_connection.go
@@ -149,6 +149,21 @@ func (r *DatadogConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(DatadogSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := DatadogConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -293,6 +308,15 @@ func (r *DatadogConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := DatadogConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_dayforce_connection.go
+++ b/provider/internal/connections/resource_dayforce_connection.go
@@ -159,6 +159,21 @@ func (r *DayforceConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(DayforceSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := DayforceConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -307,6 +322,15 @@ func (r *DayforceConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := DayforceConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_dbtcloud_connection.go
+++ b/provider/internal/connections/resource_dbtcloud_connection.go
@@ -143,6 +143,21 @@ func (r *DbtcloudConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(DbtcloudSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := DbtcloudConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -287,6 +302,15 @@ func (r *DbtcloudConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := DbtcloudConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_dbtprojectrepository_connection.go
+++ b/provider/internal/connections/resource_dbtprojectrepository_connection.go
@@ -215,6 +215,21 @@ func (r *DbtprojectrepositoryConnectionResource) Create(ctx context.Context, req
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(DbtprojectrepositorySchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := DbtprojectrepositoryConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -379,6 +394,15 @@ func (r *DbtprojectrepositoryConnectionResource) Update(ctx context.Context, req
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := DbtprojectrepositoryConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_delighted_connection.go
+++ b/provider/internal/connections/resource_delighted_connection.go
@@ -135,6 +135,21 @@ func (r *DelightedConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(DelightedSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := DelightedConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *DelightedConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := DelightedConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_dialpad_connection.go
+++ b/provider/internal/connections/resource_dialpad_connection.go
@@ -190,6 +190,21 @@ func (r *DialpadConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(DialpadSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := DialpadConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -342,6 +357,15 @@ func (r *DialpadConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := DialpadConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_dittofeed_connection.go
+++ b/provider/internal/connections/resource_dittofeed_connection.go
@@ -143,6 +143,21 @@ func (r *DittofeedConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(DittofeedSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := DittofeedConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -287,6 +302,15 @@ func (r *DittofeedConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := DittofeedConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_docker_hub_connection.go
+++ b/provider/internal/connections/resource_docker_hub_connection.go
@@ -132,6 +132,21 @@ func (r *Docker_hubConnectionResource) Create(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Docker_hubSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Docker_hubConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -274,6 +289,15 @@ func (r *Docker_hubConnectionResource) Update(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Docker_hubConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_dropbox_connection.go
+++ b/provider/internal/connections/resource_dropbox_connection.go
@@ -253,6 +253,21 @@ func (r *DropboxConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(DropboxSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := DropboxConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -423,6 +438,15 @@ func (r *DropboxConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := DropboxConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_dub_connection.go
+++ b/provider/internal/connections/resource_dub_connection.go
@@ -135,6 +135,21 @@ func (r *DubConnectionResource) Create(ctx context.Context, req resource.CreateR
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(DubSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := DubConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *DubConnectionResource) Update(ctx context.Context, req resource.UpdateR
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := DubConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_dynamodb_connection.go
+++ b/provider/internal/connections/resource_dynamodb_connection.go
@@ -212,6 +212,21 @@ func (r *DynamodbConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(DynamodbSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := DynamodbConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -370,6 +385,15 @@ func (r *DynamodbConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := DynamodbConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_factors_ai_connection.go
+++ b/provider/internal/connections/resource_factors_ai_connection.go
@@ -143,6 +143,21 @@ func (r *Factors_aiConnectionResource) Create(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Factors_aiSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Factors_aiConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -287,6 +302,15 @@ func (r *Factors_aiConnectionResource) Update(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Factors_aiConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_fathom_connection.go
+++ b/provider/internal/connections/resource_fathom_connection.go
@@ -135,6 +135,21 @@ func (r *FathomConnectionResource) Create(ctx context.Context, req resource.Crea
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(FathomSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := FathomConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *FathomConnectionResource) Update(ctx context.Context, req resource.Upda
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := FathomConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_fbaudience_connection.go
+++ b/provider/internal/connections/resource_fbaudience_connection.go
@@ -194,6 +194,21 @@ func (r *FbaudienceConnectionResource) Create(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(FbaudienceSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := FbaudienceConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -358,6 +373,15 @@ func (r *FbaudienceConnectionResource) Update(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := FbaudienceConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_fireflies_ai_connection.go
+++ b/provider/internal/connections/resource_fireflies_ai_connection.go
@@ -135,6 +135,21 @@ func (r *Fireflies_aiConnectionResource) Create(ctx context.Context, req resourc
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Fireflies_aiSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Fireflies_aiConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *Fireflies_aiConnectionResource) Update(ctx context.Context, req resourc
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Fireflies_aiConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_freshdesk_connection.go
+++ b/provider/internal/connections/resource_freshdesk_connection.go
@@ -143,6 +143,21 @@ func (r *FreshdeskConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(FreshdeskSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := FreshdeskConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -287,6 +302,15 @@ func (r *FreshdeskConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := FreshdeskConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_freshservice_connection.go
+++ b/provider/internal/connections/resource_freshservice_connection.go
@@ -140,6 +140,21 @@ func (r *FreshserviceConnectionResource) Create(ctx context.Context, req resourc
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(FreshserviceSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := FreshserviceConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -284,6 +299,15 @@ func (r *FreshserviceConnectionResource) Update(ctx context.Context, req resourc
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := FreshserviceConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_front_connection.go
+++ b/provider/internal/connections/resource_front_connection.go
@@ -135,6 +135,21 @@ func (r *FrontConnectionResource) Create(ctx context.Context, req resource.Creat
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(FrontSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := FrontConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *FrontConnectionResource) Update(ctx context.Context, req resource.Updat
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := FrontConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_fullstory_connection.go
+++ b/provider/internal/connections/resource_fullstory_connection.go
@@ -135,6 +135,21 @@ func (r *FullstoryConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(FullstorySchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := FullstoryConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *FullstoryConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := FullstoryConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_g2_connection.go
+++ b/provider/internal/connections/resource_g2_connection.go
@@ -135,6 +135,21 @@ func (r *G2ConnectionResource) Create(ctx context.Context, req resource.CreateRe
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(G2Schema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := G2Conf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *G2ConnectionResource) Update(ctx context.Context, req resource.UpdateRe
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := G2Conf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_gainsight_cs_connection.go
+++ b/provider/internal/connections/resource_gainsight_cs_connection.go
@@ -145,6 +145,21 @@ func (r *Gainsight_csConnectionResource) Create(ctx context.Context, req resourc
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Gainsight_csSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Gainsight_csConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -289,6 +304,15 @@ func (r *Gainsight_csConnectionResource) Update(ctx context.Context, req resourc
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Gainsight_csConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_gatsby_connection.go
+++ b/provider/internal/connections/resource_gatsby_connection.go
@@ -172,6 +172,21 @@ func (r *GatsbyConnectionResource) Create(ctx context.Context, req resource.Crea
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(GatsbySchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := GatsbyConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -332,6 +347,15 @@ func (r *GatsbyConnectionResource) Update(ctx context.Context, req resource.Upda
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := GatsbyConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_gcs_connection.go
+++ b/provider/internal/connections/resource_gcs_connection.go
@@ -239,6 +239,21 @@ func (r *GcsConnectionResource) Create(ctx context.Context, req resource.CreateR
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(GcsSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := GcsConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -407,6 +422,15 @@ func (r *GcsConnectionResource) Update(ctx context.Context, req resource.UpdateR
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := GcsConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_github_connection.go
+++ b/provider/internal/connections/resource_github_connection.go
@@ -194,6 +194,21 @@ func (r *GithubConnectionResource) Create(ctx context.Context, req resource.Crea
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(GithubSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := GithubConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -358,6 +373,15 @@ func (r *GithubConnectionResource) Update(ctx context.Context, req resource.Upda
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := GithubConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_gladly_connection.go
+++ b/provider/internal/connections/resource_gladly_connection.go
@@ -157,6 +157,21 @@ func (r *GladlyConnectionResource) Create(ctx context.Context, req resource.Crea
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(GladlySchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := GladlyConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -303,6 +318,15 @@ func (r *GladlyConnectionResource) Update(ctx context.Context, req resource.Upda
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := GladlyConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_glean_connection.go
+++ b/provider/internal/connections/resource_glean_connection.go
@@ -143,6 +143,21 @@ func (r *GleanConnectionResource) Create(ctx context.Context, req resource.Creat
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(GleanSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := GleanConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -287,6 +302,15 @@ func (r *GleanConnectionResource) Update(ctx context.Context, req resource.Updat
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := GleanConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_gmail_connection.go
+++ b/provider/internal/connections/resource_gmail_connection.go
@@ -173,6 +173,21 @@ func (r *GmailConnectionResource) Create(ctx context.Context, req resource.Creat
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(GmailSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := GmailConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -323,6 +338,15 @@ func (r *GmailConnectionResource) Update(ctx context.Context, req resource.Updat
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := GmailConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_gong_connection.go
+++ b/provider/internal/connections/resource_gong_connection.go
@@ -206,6 +206,21 @@ func (r *GongConnectionResource) Create(ctx context.Context, req resource.Create
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(GongSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := GongConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -362,6 +377,15 @@ func (r *GongConnectionResource) Update(ctx context.Context, req resource.Update
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := GongConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_googleads_connection.go
+++ b/provider/internal/connections/resource_googleads_connection.go
@@ -222,6 +222,21 @@ func (r *GoogleadsConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(GoogleadsSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := GoogleadsConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -392,6 +407,15 @@ func (r *GoogleadsConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := GoogleadsConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_googleanalytics_connection.go
+++ b/provider/internal/connections/resource_googleanalytics_connection.go
@@ -237,6 +237,21 @@ func (r *GoogleanalyticsConnectionResource) Create(ctx context.Context, req reso
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(GoogleanalyticsSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := GoogleanalyticsConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -409,6 +424,15 @@ func (r *GoogleanalyticsConnectionResource) Update(ctx context.Context, req reso
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := GoogleanalyticsConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_googlecloudmysql_connection.go
+++ b/provider/internal/connections/resource_googlecloudmysql_connection.go
@@ -180,6 +180,21 @@ func (r *GooglecloudmysqlConnectionResource) Create(ctx context.Context, req res
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(GooglecloudmysqlSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := GooglecloudmysqlConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -332,6 +347,15 @@ func (r *GooglecloudmysqlConnectionResource) Update(ctx context.Context, req res
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := GooglecloudmysqlConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_googlecloudsql_connection.go
+++ b/provider/internal/connections/resource_googlecloudsql_connection.go
@@ -188,6 +188,21 @@ func (r *GooglecloudsqlConnectionResource) Create(ctx context.Context, req resou
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(GooglecloudsqlSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := GooglecloudsqlConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -342,6 +357,15 @@ func (r *GooglecloudsqlConnectionResource) Update(ctx context.Context, req resou
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := GooglecloudsqlConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_googlesearchconsole_connection.go
+++ b/provider/internal/connections/resource_googlesearchconsole_connection.go
@@ -194,6 +194,21 @@ func (r *GooglesearchconsoleConnectionResource) Create(ctx context.Context, req 
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(GooglesearchconsoleSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := GooglesearchconsoleConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -358,6 +373,15 @@ func (r *GooglesearchconsoleConnectionResource) Update(ctx context.Context, req 
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := GooglesearchconsoleConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_googleslides_connection.go
+++ b/provider/internal/connections/resource_googleslides_connection.go
@@ -233,6 +233,21 @@ func (r *GoogleslidesConnectionResource) Create(ctx context.Context, req resourc
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(GoogleslidesSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := GoogleslidesConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -399,6 +414,15 @@ func (r *GoogleslidesConnectionResource) Update(ctx context.Context, req resourc
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := GoogleslidesConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_googleworkspace_connection.go
+++ b/provider/internal/connections/resource_googleworkspace_connection.go
@@ -195,6 +195,21 @@ func (r *GoogleworkspaceConnectionResource) Create(ctx context.Context, req reso
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(GoogleworkspaceSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := GoogleworkspaceConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -349,6 +364,15 @@ func (r *GoogleworkspaceConnectionResource) Update(ctx context.Context, req reso
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := GoogleworkspaceConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_gorgias_connection.go
+++ b/provider/internal/connections/resource_gorgias_connection.go
@@ -151,6 +151,21 @@ func (r *GorgiasConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(GorgiasSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := GorgiasConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -297,6 +312,15 @@ func (r *GorgiasConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := GorgiasConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_greenhouse_connection.go
+++ b/provider/internal/connections/resource_greenhouse_connection.go
@@ -171,6 +171,21 @@ func (r *GreenhouseConnectionResource) Create(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(GreenhouseSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := GreenhouseConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -319,6 +334,15 @@ func (r *GreenhouseConnectionResource) Update(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := GreenhouseConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_gsheets_connection.go
+++ b/provider/internal/connections/resource_gsheets_connection.go
@@ -233,6 +233,21 @@ func (r *GsheetsConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(GsheetsSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := GsheetsConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -399,6 +414,15 @@ func (r *GsheetsConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := GsheetsConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_harmonic_connection.go
+++ b/provider/internal/connections/resource_harmonic_connection.go
@@ -143,6 +143,21 @@ func (r *HarmonicConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(HarmonicSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := HarmonicConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -287,6 +302,15 @@ func (r *HarmonicConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := HarmonicConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_heap_connection.go
+++ b/provider/internal/connections/resource_heap_connection.go
@@ -132,6 +132,21 @@ func (r *HeapConnectionResource) Create(ctx context.Context, req resource.Create
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(HeapSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := HeapConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -274,6 +289,15 @@ func (r *HeapConnectionResource) Update(ctx context.Context, req resource.Update
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := HeapConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_herondata_connection.go
+++ b/provider/internal/connections/resource_herondata_connection.go
@@ -135,6 +135,21 @@ func (r *HerondataConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(HerondataSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := HerondataConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *HerondataConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := HerondataConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_heyreach_connection.go
+++ b/provider/internal/connections/resource_heyreach_connection.go
@@ -135,6 +135,21 @@ func (r *HeyreachConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(HeyreachSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := HeyreachConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *HeyreachConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := HeyreachConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_highlevel_connection.go
+++ b/provider/internal/connections/resource_highlevel_connection.go
@@ -135,6 +135,21 @@ func (r *HighlevelConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(HighlevelSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := HighlevelConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *HighlevelConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := HighlevelConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_highspot_connection.go
+++ b/provider/internal/connections/resource_highspot_connection.go
@@ -143,6 +143,21 @@ func (r *HighspotConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(HighspotSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := HighspotConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -287,6 +302,15 @@ func (r *HighspotConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := HighspotConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_honeycomb_connection.go
+++ b/provider/internal/connections/resource_honeycomb_connection.go
@@ -143,6 +143,21 @@ func (r *HoneycombConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(HoneycombSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := HoneycombConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -287,6 +302,15 @@ func (r *HoneycombConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := HoneycombConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_httpenrichment_connection.go
+++ b/provider/internal/connections/resource_httpenrichment_connection.go
@@ -466,6 +466,21 @@ func (r *HttpenrichmentConnectionResource) Create(ctx context.Context, req resou
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(HttpenrichmentSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := HttpenrichmentConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -752,6 +767,15 @@ func (r *HttpenrichmentConnectionResource) Update(ctx context.Context, req resou
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := HttpenrichmentConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_hubspot_connection.go
+++ b/provider/internal/connections/resource_hubspot_connection.go
@@ -189,6 +189,21 @@ func (r *HubspotConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(HubspotSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := HubspotConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -343,6 +358,15 @@ func (r *HubspotConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := HubspotConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_hyperline_connection.go
+++ b/provider/internal/connections/resource_hyperline_connection.go
@@ -135,6 +135,21 @@ func (r *HyperlineConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(HyperlineSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := HyperlineConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *HyperlineConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := HyperlineConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_ibm_db2_connection.go
+++ b/provider/internal/connections/resource_ibm_db2_connection.go
@@ -167,6 +167,21 @@ func (r *Ibm_db2ConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Ibm_db2Schema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Ibm_db2Conf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -317,6 +332,15 @@ func (r *Ibm_db2ConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Ibm_db2Conf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_instantly_connection.go
+++ b/provider/internal/connections/resource_instantly_connection.go
@@ -135,6 +135,21 @@ func (r *InstantlyConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(InstantlySchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := InstantlyConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *InstantlyConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := InstantlyConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_intellimize_connection.go
+++ b/provider/internal/connections/resource_intellimize_connection.go
@@ -135,6 +135,21 @@ func (r *IntellimizeConnectionResource) Create(ctx context.Context, req resource
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(IntellimizeSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := IntellimizeConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *IntellimizeConnectionResource) Update(ctx context.Context, req resource
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := IntellimizeConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_ironclad_connection.go
+++ b/provider/internal/connections/resource_ironclad_connection.go
@@ -187,6 +187,21 @@ func (r *IroncladConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(IroncladSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := IroncladConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -339,6 +354,15 @@ func (r *IroncladConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := IroncladConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_iterable_connection.go
+++ b/provider/internal/connections/resource_iterable_connection.go
@@ -164,6 +164,21 @@ func (r *IterableConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(IterableSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := IterableConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -322,6 +337,15 @@ func (r *IterableConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := IterableConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_jira_connection.go
+++ b/provider/internal/connections/resource_jira_connection.go
@@ -176,6 +176,21 @@ func (r *JiraConnectionResource) Create(ctx context.Context, req resource.Create
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(JiraSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := JiraConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -326,6 +341,15 @@ func (r *JiraConnectionResource) Update(ctx context.Context, req resource.Update
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := JiraConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_juro_connection.go
+++ b/provider/internal/connections/resource_juro_connection.go
@@ -135,6 +135,21 @@ func (r *JuroConnectionResource) Create(ctx context.Context, req resource.Create
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(JuroSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := JuroConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *JuroConnectionResource) Update(ctx context.Context, req resource.Update
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := JuroConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_klaviyo_connection.go
+++ b/provider/internal/connections/resource_klaviyo_connection.go
@@ -146,6 +146,21 @@ func (r *KlaviyoConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(KlaviyoSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := KlaviyoConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -290,6 +305,15 @@ func (r *KlaviyoConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := KlaviyoConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_kustomer_connection.go
+++ b/provider/internal/connections/resource_kustomer_connection.go
@@ -145,6 +145,21 @@ func (r *KustomerConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(KustomerSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := KustomerConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -289,6 +304,15 @@ func (r *KustomerConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := KustomerConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_lago_connection.go
+++ b/provider/internal/connections/resource_lago_connection.go
@@ -135,6 +135,21 @@ func (r *LagoConnectionResource) Create(ctx context.Context, req resource.Create
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(LagoSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := LagoConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *LagoConnectionResource) Update(ctx context.Context, req resource.Update
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := LagoConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_learnworlds_connection.go
+++ b/provider/internal/connections/resource_learnworlds_connection.go
@@ -151,6 +151,21 @@ func (r *LearnworldsConnectionResource) Create(ctx context.Context, req resource
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(LearnworldsSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := LearnworldsConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -297,6 +312,15 @@ func (r *LearnworldsConnectionResource) Update(ctx context.Context, req resource
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := LearnworldsConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_linear_connection.go
+++ b/provider/internal/connections/resource_linear_connection.go
@@ -135,6 +135,21 @@ func (r *LinearConnectionResource) Create(ctx context.Context, req resource.Crea
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(LinearSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := LinearConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *LinearConnectionResource) Update(ctx context.Context, req resource.Upda
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := LinearConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_linkedinads_connection.go
+++ b/provider/internal/connections/resource_linkedinads_connection.go
@@ -202,6 +202,21 @@ func (r *LinkedinadsConnectionResource) Create(ctx context.Context, req resource
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(LinkedinadsSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := LinkedinadsConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -368,6 +383,15 @@ func (r *LinkedinadsConnectionResource) Update(ctx context.Context, req resource
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := LinkedinadsConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_lob_connection.go
+++ b/provider/internal/connections/resource_lob_connection.go
@@ -135,6 +135,21 @@ func (r *LobConnectionResource) Create(ctx context.Context, req resource.CreateR
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(LobSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := LobConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *LobConnectionResource) Update(ctx context.Context, req resource.UpdateR
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := LobConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_loop_connection.go
+++ b/provider/internal/connections/resource_loop_connection.go
@@ -135,6 +135,21 @@ func (r *LoopConnectionResource) Create(ctx context.Context, req resource.Create
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(LoopSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := LoopConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *LoopConnectionResource) Update(ctx context.Context, req resource.Update
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := LoopConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_loops_connection.go
+++ b/provider/internal/connections/resource_loops_connection.go
@@ -135,6 +135,21 @@ func (r *LoopsConnectionResource) Create(ctx context.Context, req resource.Creat
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(LoopsSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := LoopsConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *LoopsConnectionResource) Update(ctx context.Context, req resource.Updat
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := LoopsConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_m3ter_connection.go
+++ b/provider/internal/connections/resource_m3ter_connection.go
@@ -154,6 +154,21 @@ func (r *M3terConnectionResource) Create(ctx context.Context, req resource.Creat
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(M3terSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := M3terConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -300,6 +315,15 @@ func (r *M3terConnectionResource) Update(ctx context.Context, req resource.Updat
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := M3terConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_mailercheck_connection.go
+++ b/provider/internal/connections/resource_mailercheck_connection.go
@@ -135,6 +135,21 @@ func (r *MailercheckConnectionResource) Create(ctx context.Context, req resource
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(MailercheckSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := MailercheckConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *MailercheckConnectionResource) Update(ctx context.Context, req resource
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := MailercheckConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_marketo_connection.go
+++ b/provider/internal/connections/resource_marketo_connection.go
@@ -191,6 +191,21 @@ func (r *MarketoConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(MarketoSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := MarketoConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -347,6 +362,15 @@ func (r *MarketoConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := MarketoConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_mixpanel_connection.go
+++ b/provider/internal/connections/resource_mixpanel_connection.go
@@ -165,6 +165,21 @@ func (r *MixpanelConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(MixpanelSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := MixpanelConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -313,6 +328,15 @@ func (r *MixpanelConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := MixpanelConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_monday_connection.go
+++ b/provider/internal/connections/resource_monday_connection.go
@@ -135,6 +135,21 @@ func (r *MondayConnectionResource) Create(ctx context.Context, req resource.Crea
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(MondaySchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := MondayConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *MondayConnectionResource) Update(ctx context.Context, req resource.Upda
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := MondayConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_mongodb_connection.go
+++ b/provider/internal/connections/resource_mongodb_connection.go
@@ -193,6 +193,21 @@ func (r *MongodbConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(MongodbSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := MongodbConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -349,6 +364,15 @@ func (r *MongodbConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := MongodbConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_motherduck_connection.go
+++ b/provider/internal/connections/resource_motherduck_connection.go
@@ -190,6 +190,21 @@ func (r *MotherduckConnectionResource) Create(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(MotherduckSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := MotherduckConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -344,6 +359,15 @@ func (r *MotherduckConnectionResource) Update(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := MotherduckConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_msads_connection.go
+++ b/provider/internal/connections/resource_msads_connection.go
@@ -216,6 +216,21 @@ func (r *MsadsConnectionResource) Create(ctx context.Context, req resource.Creat
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(MsadsSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := MsadsConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -384,6 +399,15 @@ func (r *MsadsConnectionResource) Update(ctx context.Context, req resource.Updat
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := MsadsConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_msdynamics_connection.go
+++ b/provider/internal/connections/resource_msdynamics_connection.go
@@ -173,6 +173,21 @@ func (r *MsdynamicsConnectionResource) Create(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(MsdynamicsSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := MsdynamicsConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -323,6 +338,15 @@ func (r *MsdynamicsConnectionResource) Update(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := MsdynamicsConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_mssql_connection.go
+++ b/provider/internal/connections/resource_mssql_connection.go
@@ -226,6 +226,21 @@ func (r *MssqlConnectionResource) Create(ctx context.Context, req resource.Creat
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(MssqlSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := MssqlConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -390,6 +405,15 @@ func (r *MssqlConnectionResource) Update(ctx context.Context, req resource.Updat
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := MssqlConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_mysql_connection.go
+++ b/provider/internal/connections/resource_mysql_connection.go
@@ -226,6 +226,21 @@ func (r *MysqlConnectionResource) Create(ctx context.Context, req resource.Creat
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(MysqlSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := MysqlConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -390,6 +405,15 @@ func (r *MysqlConnectionResource) Update(ctx context.Context, req resource.Updat
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := MysqlConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_n8n_connection.go
+++ b/provider/internal/connections/resource_n8n_connection.go
@@ -145,6 +145,21 @@ func (r *N8nConnectionResource) Create(ctx context.Context, req resource.CreateR
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(N8nSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := N8nConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -289,6 +304,15 @@ func (r *N8nConnectionResource) Update(ctx context.Context, req resource.UpdateR
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := N8nConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_netsuite_connection.go
+++ b/provider/internal/connections/resource_netsuite_connection.go
@@ -170,6 +170,21 @@ func (r *NetsuiteConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(NetsuiteSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := NetsuiteConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -320,6 +335,15 @@ func (r *NetsuiteConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := NetsuiteConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_netsuiteopenair_connection.go
+++ b/provider/internal/connections/resource_netsuiteopenair_connection.go
@@ -189,6 +189,21 @@ func (r *NetsuiteopenairConnectionResource) Create(ctx context.Context, req reso
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(NetsuiteopenairSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := NetsuiteopenairConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -343,6 +358,15 @@ func (r *NetsuiteopenairConnectionResource) Update(ctx context.Context, req reso
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := NetsuiteopenairConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_netsuitesaconnect_connection.go
+++ b/provider/internal/connections/resource_netsuitesaconnect_connection.go
@@ -167,6 +167,21 @@ func (r *NetsuitesaconnectConnectionResource) Create(ctx context.Context, req re
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(NetsuitesaconnectSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := NetsuitesaconnectConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -317,6 +332,15 @@ func (r *NetsuitesaconnectConnectionResource) Update(ctx context.Context, req re
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := NetsuitesaconnectConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_northbeam_connection.go
+++ b/provider/internal/connections/resource_northbeam_connection.go
@@ -157,6 +157,21 @@ func (r *NorthbeamConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(NorthbeamSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := NorthbeamConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -303,6 +318,15 @@ func (r *NorthbeamConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := NorthbeamConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_outreach_connection.go
+++ b/provider/internal/connections/resource_outreach_connection.go
@@ -181,6 +181,21 @@ func (r *OutreachConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(OutreachSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := OutreachConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -333,6 +348,15 @@ func (r *OutreachConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := OutreachConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_pardot_connection.go
+++ b/provider/internal/connections/resource_pardot_connection.go
@@ -170,6 +170,21 @@ func (r *PardotConnectionResource) Create(ctx context.Context, req resource.Crea
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(PardotSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := PardotConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -320,6 +335,15 @@ func (r *PardotConnectionResource) Update(ctx context.Context, req resource.Upda
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := PardotConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_partnerpage_connection.go
+++ b/provider/internal/connections/resource_partnerpage_connection.go
@@ -135,6 +135,21 @@ func (r *PartnerpageConnectionResource) Create(ctx context.Context, req resource
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(PartnerpageSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := PartnerpageConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *PartnerpageConnectionResource) Update(ctx context.Context, req resource
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := PartnerpageConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_paycor_connection.go
+++ b/provider/internal/connections/resource_paycor_connection.go
@@ -173,6 +173,21 @@ func (r *PaycorConnectionResource) Create(ctx context.Context, req resource.Crea
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(PaycorSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := PaycorConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -323,6 +338,15 @@ func (r *PaycorConnectionResource) Update(ctx context.Context, req resource.Upda
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := PaycorConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_pinterest_ads_connection.go
+++ b/provider/internal/connections/resource_pinterest_ads_connection.go
@@ -183,6 +183,21 @@ func (r *Pinterest_adsConnectionResource) Create(ctx context.Context, req resour
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Pinterest_adsSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Pinterest_adsConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -345,6 +360,15 @@ func (r *Pinterest_adsConnectionResource) Update(ctx context.Context, req resour
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Pinterest_adsConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_pipedrive_connection.go
+++ b/provider/internal/connections/resource_pipedrive_connection.go
@@ -143,6 +143,21 @@ func (r *PipedriveConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(PipedriveSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := PipedriveConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -287,6 +302,15 @@ func (r *PipedriveConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := PipedriveConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_pitchbook_connection.go
+++ b/provider/internal/connections/resource_pitchbook_connection.go
@@ -132,6 +132,21 @@ func (r *PitchbookConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(PitchbookSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := PitchbookConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -274,6 +289,15 @@ func (r *PitchbookConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := PitchbookConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_plain_connection.go
+++ b/provider/internal/connections/resource_plain_connection.go
@@ -137,6 +137,21 @@ func (r *PlainConnectionResource) Create(ctx context.Context, req resource.Creat
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(PlainSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := PlainConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -279,6 +294,15 @@ func (r *PlainConnectionResource) Update(ctx context.Context, req resource.Updat
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := PlainConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_plusvibe_connection.go
+++ b/provider/internal/connections/resource_plusvibe_connection.go
@@ -164,6 +164,21 @@ func (r *PlusvibeConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(PlusvibeSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := PlusvibeConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -322,6 +337,15 @@ func (r *PlusvibeConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := PlusvibeConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_polytomic_metadata_connection.go
+++ b/provider/internal/connections/resource_polytomic_metadata_connection.go
@@ -193,6 +193,21 @@ func (r *Polytomic_metadataConnectionResource) Create(ctx context.Context, req r
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Polytomic_metadataSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Polytomic_metadataConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -345,6 +360,15 @@ func (r *Polytomic_metadataConnectionResource) Update(ctx context.Context, req r
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Polytomic_metadataConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_postgresql_connection.go
+++ b/provider/internal/connections/resource_postgresql_connection.go
@@ -275,6 +275,21 @@ func (r *PostgresqlConnectionResource) Create(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(PostgresqlSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := PostgresqlConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -449,6 +464,15 @@ func (r *PostgresqlConnectionResource) Update(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := PostgresqlConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_posthog_connection.go
+++ b/provider/internal/connections/resource_posthog_connection.go
@@ -165,6 +165,21 @@ func (r *PosthogConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(PosthogSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := PosthogConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -313,6 +328,15 @@ func (r *PosthogConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := PosthogConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_predictleads_connection.go
+++ b/provider/internal/connections/resource_predictleads_connection.go
@@ -146,6 +146,21 @@ func (r *PredictleadsConnectionResource) Create(ctx context.Context, req resourc
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(PredictleadsSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := PredictleadsConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -290,6 +305,15 @@ func (r *PredictleadsConnectionResource) Update(ctx context.Context, req resourc
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := PredictleadsConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_productboard_connection.go
+++ b/provider/internal/connections/resource_productboard_connection.go
@@ -135,6 +135,21 @@ func (r *ProductboardConnectionResource) Create(ctx context.Context, req resourc
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(ProductboardSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := ProductboardConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *ProductboardConnectionResource) Update(ctx context.Context, req resourc
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := ProductboardConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_profound_connection.go
+++ b/provider/internal/connections/resource_profound_connection.go
@@ -135,6 +135,21 @@ func (r *ProfoundConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(ProfoundSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := ProfoundConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *ProfoundConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := ProfoundConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_pylon_connection.go
+++ b/provider/internal/connections/resource_pylon_connection.go
@@ -135,6 +135,21 @@ func (r *PylonConnectionResource) Create(ctx context.Context, req resource.Creat
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(PylonSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := PylonConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *PylonConnectionResource) Update(ctx context.Context, req resource.Updat
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := PylonConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_qualtrics_connection.go
+++ b/provider/internal/connections/resource_qualtrics_connection.go
@@ -149,6 +149,21 @@ func (r *QualtricsConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(QualtricsSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := QualtricsConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -293,6 +308,15 @@ func (r *QualtricsConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := QualtricsConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_quickbooks_connection.go
+++ b/provider/internal/connections/resource_quickbooks_connection.go
@@ -173,6 +173,21 @@ func (r *QuickbooksConnectionResource) Create(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(QuickbooksSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := QuickbooksConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -323,6 +338,15 @@ func (r *QuickbooksConnectionResource) Update(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := QuickbooksConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_ramp_connection.go
+++ b/provider/internal/connections/resource_ramp_connection.go
@@ -173,6 +173,21 @@ func (r *RampConnectionResource) Create(ctx context.Context, req resource.Create
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(RampSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := RampConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -323,6 +338,15 @@ func (r *RampConnectionResource) Update(ctx context.Context, req resource.Update
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := RampConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_recharge_connection.go
+++ b/provider/internal/connections/resource_recharge_connection.go
@@ -135,6 +135,21 @@ func (r *RechargeConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(RechargeSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := RechargeConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *RechargeConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := RechargeConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_redditads_connection.go
+++ b/provider/internal/connections/resource_redditads_connection.go
@@ -212,6 +212,21 @@ func (r *RedditadsConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(RedditadsSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := RedditadsConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -380,6 +395,15 @@ func (r *RedditadsConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := RedditadsConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_redshift_connection.go
+++ b/provider/internal/connections/resource_redshift_connection.go
@@ -309,6 +309,21 @@ func (r *RedshiftConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(RedshiftSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := RedshiftConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -489,6 +504,15 @@ func (r *RedshiftConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := RedshiftConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_redshiftserverless_connection.go
+++ b/provider/internal/connections/resource_redshiftserverless_connection.go
@@ -244,6 +244,21 @@ func (r *RedshiftserverlessConnectionResource) Create(ctx context.Context, req r
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(RedshiftserverlessSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := RedshiftserverlessConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -412,6 +427,15 @@ func (r *RedshiftserverlessConnectionResource) Update(ctx context.Context, req r
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := RedshiftserverlessConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_replyio_connection.go
+++ b/provider/internal/connections/resource_replyio_connection.go
@@ -135,6 +135,21 @@ func (r *ReplyioConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(ReplyioSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := ReplyioConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *ReplyioConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := ReplyioConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_rewardful_connection.go
+++ b/provider/internal/connections/resource_rewardful_connection.go
@@ -135,6 +135,21 @@ func (r *RewardfulConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(RewardfulSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := RewardfulConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *RewardfulConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := RewardfulConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_rippling_connection.go
+++ b/provider/internal/connections/resource_rippling_connection.go
@@ -135,6 +135,21 @@ func (r *RipplingConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(RipplingSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := RipplingConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *RipplingConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := RipplingConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_rocketlane_connection.go
+++ b/provider/internal/connections/resource_rocketlane_connection.go
@@ -135,6 +135,21 @@ func (r *RocketlaneConnectionResource) Create(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(RocketlaneSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := RocketlaneConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *RocketlaneConnectionResource) Update(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := RocketlaneConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_s3_connection.go
+++ b/provider/internal/connections/resource_s3_connection.go
@@ -302,6 +302,21 @@ func (r *S3ConnectionResource) Create(ctx context.Context, req resource.CreateRe
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(S3Schema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := S3Conf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -482,6 +497,15 @@ func (r *S3ConnectionResource) Update(ctx context.Context, req resource.UpdateRe
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := S3Conf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_sageintacct_connection.go
+++ b/provider/internal/connections/resource_sageintacct_connection.go
@@ -165,6 +165,21 @@ func (r *SageintacctConnectionResource) Create(ctx context.Context, req resource
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(SageintacctSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := SageintacctConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -313,6 +328,15 @@ func (r *SageintacctConnectionResource) Update(ctx context.Context, req resource
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := SageintacctConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_salesbricks_connection.go
+++ b/provider/internal/connections/resource_salesbricks_connection.go
@@ -135,6 +135,21 @@ func (r *SalesbricksConnectionResource) Create(ctx context.Context, req resource
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(SalesbricksSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := SalesbricksConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *SalesbricksConnectionResource) Update(ctx context.Context, req resource
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := SalesbricksConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_salesforce_connection.go
+++ b/provider/internal/connections/resource_salesforce_connection.go
@@ -237,6 +237,21 @@ func (r *SalesforceConnectionResource) Create(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(SalesforceSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := SalesforceConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -399,6 +414,15 @@ func (r *SalesforceConnectionResource) Update(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := SalesforceConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_salesloft_connection.go
+++ b/provider/internal/connections/resource_salesloft_connection.go
@@ -198,6 +198,21 @@ func (r *SalesloftConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(SalesloftSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := SalesloftConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -352,6 +367,15 @@ func (r *SalesloftConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := SalesloftConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_scamalytics_connection.go
+++ b/provider/internal/connections/resource_scamalytics_connection.go
@@ -143,6 +143,21 @@ func (r *ScamalyticsConnectionResource) Create(ctx context.Context, req resource
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(ScamalyticsSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := ScamalyticsConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -287,6 +302,15 @@ func (r *ScamalyticsConnectionResource) Update(ctx context.Context, req resource
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := ScamalyticsConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_seal_subscriptions_connection.go
+++ b/provider/internal/connections/resource_seal_subscriptions_connection.go
@@ -135,6 +135,21 @@ func (r *Seal_subscriptionsConnectionResource) Create(ctx context.Context, req r
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Seal_subscriptionsSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Seal_subscriptionsConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *Seal_subscriptionsConnectionResource) Update(ctx context.Context, req r
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Seal_subscriptionsConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_seamai_connection.go
+++ b/provider/internal/connections/resource_seamai_connection.go
@@ -156,6 +156,21 @@ func (r *SeamaiConnectionResource) Create(ctx context.Context, req resource.Crea
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(SeamaiSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := SeamaiConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -302,6 +317,15 @@ func (r *SeamaiConnectionResource) Update(ctx context.Context, req resource.Upda
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := SeamaiConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_segment_connection.go
+++ b/provider/internal/connections/resource_segment_connection.go
@@ -135,6 +135,21 @@ func (r *SegmentConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(SegmentSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := SegmentConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *SegmentConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := SegmentConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_seismic_connection.go
+++ b/provider/internal/connections/resource_seismic_connection.go
@@ -165,6 +165,21 @@ func (r *SeismicConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(SeismicSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := SeismicConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -313,6 +328,15 @@ func (r *SeismicConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := SeismicConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_sftp_connection.go
+++ b/provider/internal/connections/resource_sftp_connection.go
@@ -220,6 +220,21 @@ func (r *SftpConnectionResource) Create(ctx context.Context, req resource.Create
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(SftpSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := SftpConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -380,6 +395,15 @@ func (r *SftpConnectionResource) Update(ctx context.Context, req resource.Update
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := SftpConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_sharepoint_excel_connection.go
+++ b/provider/internal/connections/resource_sharepoint_excel_connection.go
@@ -176,6 +176,21 @@ func (r *Sharepoint_excelConnectionResource) Create(ctx context.Context, req res
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Sharepoint_excelSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Sharepoint_excelConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -326,6 +341,15 @@ func (r *Sharepoint_excelConnectionResource) Update(ctx context.Context, req res
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Sharepoint_excelConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_shipbob_connection.go
+++ b/provider/internal/connections/resource_shipbob_connection.go
@@ -157,6 +157,21 @@ func (r *ShipbobConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(ShipbobSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := ShipbobConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -303,6 +318,15 @@ func (r *ShipbobConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := ShipbobConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_shippo_connection.go
+++ b/provider/internal/connections/resource_shippo_connection.go
@@ -135,6 +135,21 @@ func (r *ShippoConnectionResource) Create(ctx context.Context, req resource.Crea
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(ShippoSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := ShippoConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *ShippoConnectionResource) Update(ctx context.Context, req resource.Upda
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := ShippoConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_shopify_connection.go
+++ b/provider/internal/connections/resource_shopify_connection.go
@@ -145,6 +145,21 @@ func (r *ShopifyConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(ShopifySchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := ShopifyConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -289,6 +304,15 @@ func (r *ShopifyConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := ShopifyConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_shortio_connection.go
+++ b/provider/internal/connections/resource_shortio_connection.go
@@ -135,6 +135,21 @@ func (r *ShortioConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(ShortioSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := ShortioConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *ShortioConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := ShortioConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_showpad_connection.go
+++ b/provider/internal/connections/resource_showpad_connection.go
@@ -143,6 +143,21 @@ func (r *ShowpadConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(ShowpadSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := ShowpadConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -287,6 +302,15 @@ func (r *ShowpadConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := ShowpadConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_slack_connection.go
+++ b/provider/internal/connections/resource_slack_connection.go
@@ -145,6 +145,21 @@ func (r *SlackConnectionResource) Create(ctx context.Context, req resource.Creat
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(SlackSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := SlackConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -289,6 +304,15 @@ func (r *SlackConnectionResource) Update(ctx context.Context, req resource.Updat
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := SlackConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_smartlead_connection.go
+++ b/provider/internal/connections/resource_smartlead_connection.go
@@ -135,6 +135,21 @@ func (r *SmartleadConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(SmartleadSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := SmartleadConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *SmartleadConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := SmartleadConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_smartsheet_connection.go
+++ b/provider/internal/connections/resource_smartsheet_connection.go
@@ -157,6 +157,21 @@ func (r *SmartsheetConnectionResource) Create(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(SmartsheetSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := SmartsheetConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -303,6 +318,15 @@ func (r *SmartsheetConnectionResource) Update(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := SmartsheetConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_snowflake_connection.go
+++ b/provider/internal/connections/resource_snowflake_connection.go
@@ -225,6 +225,21 @@ func (r *SnowflakeConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(SnowflakeSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := SnowflakeConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -387,6 +402,15 @@ func (r *SnowflakeConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := SnowflakeConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_sprig_connection.go
+++ b/provider/internal/connections/resource_sprig_connection.go
@@ -135,6 +135,21 @@ func (r *SprigConnectionResource) Create(ctx context.Context, req resource.Creat
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(SprigSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := SprigConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *SprigConnectionResource) Update(ctx context.Context, req resource.Updat
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := SprigConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_sproutsocial_connection.go
+++ b/provider/internal/connections/resource_sproutsocial_connection.go
@@ -147,6 +147,21 @@ func (r *SproutsocialConnectionResource) Create(ctx context.Context, req resourc
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(SproutsocialSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := SproutsocialConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -291,6 +306,15 @@ func (r *SproutsocialConnectionResource) Update(ctx context.Context, req resourc
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := SproutsocialConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_standard_metrics_connection.go
+++ b/provider/internal/connections/resource_standard_metrics_connection.go
@@ -143,6 +143,21 @@ func (r *Standard_metricsConnectionResource) Create(ctx context.Context, req res
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Standard_metricsSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Standard_metricsConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -287,6 +302,15 @@ func (r *Standard_metricsConnectionResource) Update(ctx context.Context, req res
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Standard_metricsConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_statsig_connection.go
+++ b/provider/internal/connections/resource_statsig_connection.go
@@ -135,6 +135,21 @@ func (r *StatsigConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(StatsigSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := StatsigConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *StatsigConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := StatsigConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_stord_connection.go
+++ b/provider/internal/connections/resource_stord_connection.go
@@ -151,6 +151,21 @@ func (r *StordConnectionResource) Create(ctx context.Context, req resource.Creat
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(StordSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := StordConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -297,6 +312,15 @@ func (r *StordConnectionResource) Update(ctx context.Context, req resource.Updat
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := StordConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_strackr_connection.go
+++ b/provider/internal/connections/resource_strackr_connection.go
@@ -169,6 +169,21 @@ func (r *StrackrConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(StrackrSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := StrackrConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -317,6 +332,15 @@ func (r *StrackrConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := StrackrConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_stripe_connection.go
+++ b/provider/internal/connections/resource_stripe_connection.go
@@ -135,6 +135,21 @@ func (r *StripeConnectionResource) Create(ctx context.Context, req resource.Crea
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(StripeSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := StripeConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *StripeConnectionResource) Update(ctx context.Context, req resource.Upda
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := StripeConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_surveymonkey_connection.go
+++ b/provider/internal/connections/resource_surveymonkey_connection.go
@@ -146,6 +146,21 @@ func (r *SurveymonkeyConnectionResource) Create(ctx context.Context, req resourc
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(SurveymonkeySchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := SurveymonkeyConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -290,6 +305,15 @@ func (r *SurveymonkeyConnectionResource) Update(ctx context.Context, req resourc
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := SurveymonkeyConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_survicate_connection.go
+++ b/provider/internal/connections/resource_survicate_connection.go
@@ -135,6 +135,21 @@ func (r *SurvicateConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(SurvicateSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := SurvicateConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *SurvicateConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := SurvicateConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_synapse_connection.go
+++ b/provider/internal/connections/resource_synapse_connection.go
@@ -167,6 +167,21 @@ func (r *SynapseConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(SynapseSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := SynapseConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -317,6 +332,15 @@ func (r *SynapseConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := SynapseConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_tabs_connection.go
+++ b/provider/internal/connections/resource_tabs_connection.go
@@ -135,6 +135,21 @@ func (r *TabsConnectionResource) Create(ctx context.Context, req resource.Create
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(TabsSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := TabsConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *TabsConnectionResource) Update(ctx context.Context, req resource.Update
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := TabsConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_testrail_connection.go
+++ b/provider/internal/connections/resource_testrail_connection.go
@@ -151,6 +151,21 @@ func (r *TestrailConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(TestrailSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := TestrailConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -297,6 +312,15 @@ func (r *TestrailConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := TestrailConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_thrive_connection.go
+++ b/provider/internal/connections/resource_thrive_connection.go
@@ -135,6 +135,21 @@ func (r *ThriveConnectionResource) Create(ctx context.Context, req resource.Crea
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(ThriveSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := ThriveConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *ThriveConnectionResource) Update(ctx context.Context, req resource.Upda
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := ThriveConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_tiktok_ads_connection.go
+++ b/provider/internal/connections/resource_tiktok_ads_connection.go
@@ -193,6 +193,21 @@ func (r *Tiktok_adsConnectionResource) Create(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Tiktok_adsSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Tiktok_adsConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -357,6 +372,15 @@ func (r *Tiktok_adsConnectionResource) Update(ctx context.Context, req resource.
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Tiktok_adsConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_tixr_connection.go
+++ b/provider/internal/connections/resource_tixr_connection.go
@@ -145,6 +145,21 @@ func (r *TixrConnectionResource) Create(ctx context.Context, req resource.Create
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(TixrSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := TixrConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -289,6 +304,15 @@ func (r *TixrConnectionResource) Update(ctx context.Context, req resource.Update
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := TixrConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_towbook_connection.go
+++ b/provider/internal/connections/resource_towbook_connection.go
@@ -135,6 +135,21 @@ func (r *TowbookConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(TowbookSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := TowbookConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *TowbookConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := TowbookConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_twilio_sendgrid_connection.go
+++ b/provider/internal/connections/resource_twilio_sendgrid_connection.go
@@ -135,6 +135,21 @@ func (r *Twilio_sendgridConnectionResource) Create(ctx context.Context, req reso
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Twilio_sendgridSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Twilio_sendgridConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *Twilio_sendgridConnectionResource) Update(ctx context.Context, req reso
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Twilio_sendgridConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_typeform_connection.go
+++ b/provider/internal/connections/resource_typeform_connection.go
@@ -165,6 +165,21 @@ func (r *TypeformConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(TypeformSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := TypeformConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -313,6 +328,15 @@ func (r *TypeformConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := TypeformConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_unbounce_connection.go
+++ b/provider/internal/connections/resource_unbounce_connection.go
@@ -135,6 +135,21 @@ func (r *UnbounceConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(UnbounceSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := UnbounceConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *UnbounceConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := UnbounceConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_upfluence_connection.go
+++ b/provider/internal/connections/resource_upfluence_connection.go
@@ -162,6 +162,21 @@ func (r *UpfluenceConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(UpfluenceSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := UpfluenceConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -310,6 +325,15 @@ func (r *UpfluenceConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := UpfluenceConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_uppromote_connection.go
+++ b/provider/internal/connections/resource_uppromote_connection.go
@@ -135,6 +135,21 @@ func (r *UppromoteConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(UppromoteSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := UppromoteConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *UppromoteConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := UppromoteConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_uservoice_connection.go
+++ b/provider/internal/connections/resource_uservoice_connection.go
@@ -143,6 +143,21 @@ func (r *UservoiceConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(UservoiceSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := UservoiceConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -287,6 +302,15 @@ func (r *UservoiceConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := UservoiceConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_vanilla_connection.go
+++ b/provider/internal/connections/resource_vanilla_connection.go
@@ -143,6 +143,21 @@ func (r *VanillaConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(VanillaSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := VanillaConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -287,6 +302,15 @@ func (r *VanillaConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := VanillaConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_walmart_marketplace_connection.go
+++ b/provider/internal/connections/resource_walmart_marketplace_connection.go
@@ -146,6 +146,21 @@ func (r *Walmart_marketplaceConnectionResource) Create(ctx context.Context, req 
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Walmart_marketplaceSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Walmart_marketplaceConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -290,6 +305,15 @@ func (r *Walmart_marketplaceConnectionResource) Update(ctx context.Context, req 
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Walmart_marketplaceConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_ware2go_connection.go
+++ b/provider/internal/connections/resource_ware2go_connection.go
@@ -159,6 +159,21 @@ func (r *Ware2goConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Ware2goSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Ware2goConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -307,6 +322,15 @@ func (r *Ware2goConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Ware2goConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_webhook_connection.go
+++ b/provider/internal/connections/resource_webhook_connection.go
@@ -172,6 +172,21 @@ func (r *WebhookConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(WebhookSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := WebhookConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -332,6 +347,15 @@ func (r *WebhookConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := WebhookConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_work_os_connection.go
+++ b/provider/internal/connections/resource_work_os_connection.go
@@ -135,6 +135,21 @@ func (r *Work_osConnectionResource) Create(ctx context.Context, req resource.Cre
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Work_osSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Work_osConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -277,6 +292,15 @@ func (r *Work_osConnectionResource) Update(ctx context.Context, req resource.Upd
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Work_osConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_xero_connection.go
+++ b/provider/internal/connections/resource_xero_connection.go
@@ -176,6 +176,21 @@ func (r *XeroConnectionResource) Create(ctx context.Context, req resource.Create
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(XeroSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := XeroConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -326,6 +341,15 @@ func (r *XeroConnectionResource) Update(ctx context.Context, req resource.Update
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := XeroConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_yotpo_connection.go
+++ b/provider/internal/connections/resource_yotpo_connection.go
@@ -145,6 +145,21 @@ func (r *YotpoConnectionResource) Create(ctx context.Context, req resource.Creat
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(YotpoSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := YotpoConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -289,6 +304,15 @@ func (r *YotpoConnectionResource) Update(ctx context.Context, req resource.Updat
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := YotpoConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_youtubeanalytics_connection.go
+++ b/provider/internal/connections/resource_youtubeanalytics_connection.go
@@ -183,6 +183,21 @@ func (r *YoutubeanalyticsConnectionResource) Create(ctx context.Context, req res
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(YoutubeanalyticsSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := YoutubeanalyticsConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -335,6 +350,15 @@ func (r *YoutubeanalyticsConnectionResource) Update(ctx context.Context, req res
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := YoutubeanalyticsConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_zendesk_chat_connection.go
+++ b/provider/internal/connections/resource_zendesk_chat_connection.go
@@ -150,6 +150,21 @@ func (r *Zendesk_chatConnectionResource) Create(ctx context.Context, req resourc
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Zendesk_chatSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Zendesk_chatConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -296,6 +311,15 @@ func (r *Zendesk_chatConnectionResource) Update(ctx context.Context, req resourc
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Zendesk_chatConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_zendesk_support_connection.go
+++ b/provider/internal/connections/resource_zendesk_support_connection.go
@@ -202,6 +202,21 @@ func (r *Zendesk_supportConnectionResource) Create(ctx context.Context, req reso
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Zendesk_supportSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Zendesk_supportConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -358,6 +373,15 @@ func (r *Zendesk_supportConnectionResource) Update(ctx context.Context, req reso
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Zendesk_supportConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_zoho_crm_connection.go
+++ b/provider/internal/connections/resource_zoho_crm_connection.go
@@ -168,6 +168,21 @@ func (r *Zoho_crmConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Zoho_crmSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Zoho_crmConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -316,6 +331,15 @@ func (r *Zoho_crmConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Zoho_crmConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_zoho_desk_connection.go
+++ b/provider/internal/connections/resource_zoho_desk_connection.go
@@ -186,6 +186,21 @@ func (r *Zoho_deskConnectionResource) Create(ctx context.Context, req resource.C
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(Zoho_deskSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := Zoho_deskConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -348,6 +363,15 @@ func (r *Zoho_deskConnectionResource) Update(ctx context.Context, req resource.U
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := Zoho_deskConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/internal/connections/resource_zoominfo_connection.go
+++ b/provider/internal/connections/resource_zoominfo_connection.go
@@ -151,6 +151,21 @@ func (r *ZoominfoConnectionResource) Create(ctx context.Context, req resource.Cr
 	data.Name = types.StringPointerValue(created.Data.Name)
 	data.Organization = types.StringPointerValue(created.Data.OrganizationId)
 
+	configAttributes, ok := getConfigAttributes(ZoominfoSchema)
+	if !ok {
+		resp.Diagnostics.AddError("Error getting connection configuration attributes", "Could not get configuration attributes")
+		return
+	}
+
+	originalConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the user's config
+	// so terraform doesn't see the masked values as drift
+	created.Data.Configuration = resetSensitiveValues(configAttributes, originalConfData, created.Data.Configuration)
 	conf := ZoominfoConf{}
 	err = mapstructure.Decode(created.Data.Configuration, &conf)
 	if err != nil {
@@ -297,6 +312,15 @@ func (r *ZoominfoConnectionResource) Update(ctx context.Context, req resource.Up
 	data.Name = types.StringPointerValue(updated.Data.Name)
 	data.Organization = types.StringPointerValue(updated.Data.OrganizationId)
 
+	planConfData, err := objectMapValue(ctx, data.Configuration)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting connection configuration", err.Error())
+		return
+	}
+
+	// the API masks sensitive values in responses; restore them from the plan's config
+	// so terraform doesn't see the masked values as drift
+	updated.Data.Configuration = resetSensitiveValues(configAttributes, planConfData, updated.Data.Configuration)
 	conf := ZoominfoConf{}
 	err = mapstructure.Decode(updated.Data.Configuration, &conf)
 	if err != nil {

--- a/provider/resource_postgresql_connection_test.go
+++ b/provider/resource_postgresql_connection_test.go
@@ -1,0 +1,74 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+// TestAccPostgresqlConnectionResource exercises a connection type with a
+// sensitive configuration field (password) end-to-end: Create, then the
+// framework's post-apply refresh+plan (Read) to check for drift. The Polytomic
+// API masks sensitive values in responses; the provider preserves the
+// user-supplied value via resetSensitiveValues so state stays correct and
+// terraform doesn't see the masked response as drift.
+func TestAccPostgresqlConnectionResource(t *testing.T) {
+	name := fmt.Sprintf("TestAccPGConn-%s", uuid.NewString())
+	pg := testPostgresConfig(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create: passes only if the provider echoes the password back into state.
+			// The framework also runs refresh+plan after apply and fails on drift,
+			// so the Read path is implicitly covered.
+			{
+				Config: TestCaseTfResource(t, postgresqlConnectionTemplate, TestCaseTfArgs{
+					Name:     name,
+					APIKey:   APIKey(),
+					Postgres: pg,
+				}),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"polytomic_postgresql_connection.test",
+						tfjsonpath.New("configuration").AtMapKey("password"),
+						knownvalue.StringExact(pg.Password),
+					),
+					statecheck.ExpectKnownValue(
+						"polytomic_postgresql_connection.test",
+						tfjsonpath.New("configuration").AtMapKey("hostname"),
+						knownvalue.StringExact(pg.Host),
+					),
+				},
+			},
+		},
+	})
+}
+
+const postgresqlConnectionTemplate = `
+{{if not .APIKey}}
+resource "polytomic_organization" "test" {
+  name = "{{.Name}}"
+}
+{{end}}
+
+resource "polytomic_postgresql_connection" "test" {
+  name = "{{.Name}}"
+  configuration = {
+    hostname = "{{.Postgres.Host}}"
+    database = "{{.Postgres.Database}}"
+    username = "{{.Postgres.Username}}"
+    password = "{{.Postgres.Password}}"
+    port     = {{.Postgres.Port}}
+  }
+{{if not .APIKey}}
+  organization = polytomic_organization.test.id
+{{end}}
+}
+`


### PR DESCRIPTION
The Polytomic API masks sensitive configuration fields (passwords, service account keys, certificates) in responses. Without preserving the user-supplied value, the provider stores masked values and trips "Provider produced inconsistent result after apply" on Create, or drift on subsequent plans.

Mirror the resetSensitiveValues logic that already runs in Read onto the Create and Update response paths, so the provider keeps the user-supplied value in state regardless of what the API returns.