### PR TITLE
Remove server-managed internal fields from connection schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.0.0 (unreleased)
+
+BREAKING CHANGES:
+
+- Removed server-managed internal fields from connection configurations. Fields such as `authenticated` (GitHub) and `oauth_token_expiry` were generated as `Optional` + `Computed` but tracked internal OAuth state and had no effect when set. This removes 28 fields across 27 connection types. Fields that are hidden in the UI but settable through the API (`client_id`, `client_secret`, `oauth_access_token`) are unchanged. See the [v2.0.0 upgrade guide](docs/guides/upgrading-to-v2.0.0.md) for the full list and migration steps.
+
 ## v1.5.5 (29 May 2026)
 
 - Added support for new connection types:

--- a/docs/data-sources/dbtprojectrepository_connection.md
+++ b/docs/data-sources/dbtprojectrepository_connection.md
@@ -40,7 +40,6 @@ Read-Only:
 - `commit_exposures` (Boolean) Commit exposures file
 - `connected_user` (String) Connected user
 - `latest_commit` (Attributes) Most recent exposures commit (see [below for nested schema](#nestedatt--configuration--latest_commit))
-- `oauth_token_expiry` (String)
 - `repository` (String) dbt project repository
 
     Only repositories with the Polytomic app installed will be listed.

--- a/docs/data-sources/dialpad_connection.md
+++ b/docs/data-sources/dialpad_connection.md
@@ -37,6 +37,5 @@ data "polytomic_dialpad_connection" "dialpad" {
 Read-Only:
 
 - `auth_method` (String) Authentication method Valid values: <code>api_key</code> (API Key), <code>oauth</code> (OAuth). Default: <code>api_key</code>.
-- `oauth_token_expiry` (String)
 
 

--- a/docs/data-sources/dropbox_connection.md
+++ b/docs/data-sources/dropbox_connection.md
@@ -45,7 +45,6 @@ Read-Only:
 - `is_single_table` (Boolean) Files are time-based snapshots
 
     Treat the files as a single table. Default: <code>false</code>.
-- `oauth_token_expiry` (String)
 - `single_table_file_format` (String) File format Valid values: <code>csv</code> (CSV), <code>json</code> (JSON), <code>parquet</code> (Parquet). Default: <code>csv</code>.
 - `single_table_file_formats` (Set of String) File formats
 

--- a/docs/data-sources/github_connection.md
+++ b/docs/data-sources/github_connection.md
@@ -36,7 +36,6 @@ data "polytomic_github_connection" "github" {
 
 Read-Only:
 
-- `authenticated` (Boolean)
 - `repositories` (Attributes Set) (see [below for nested schema](#nestedatt--configuration--repositories))
 
 <a id="nestedatt--configuration--repositories"></a>

--- a/docs/data-sources/gmail_connection.md
+++ b/docs/data-sources/gmail_connection.md
@@ -36,7 +36,6 @@ data "polytomic_gmail_connection" "gmail" {
 
 Read-Only:
 
-- `oauth_token_expiry` (String)
 - `user_email` (String) Connected user's email
 
 

--- a/docs/data-sources/gong_connection.md
+++ b/docs/data-sources/gong_connection.md
@@ -38,7 +38,6 @@ Read-Only:
 
 - `access_key` (String) Access key
 - `auth_method` (String) Authentication method Valid values: <code>token</code> (Access key and secret), <code>oauth</code> (OAuth). Default: <code>token</code>.
-- `oauth_token_expiry` (String)
 - `subdomain` (String) Gong subdomain i.e. company-17 if you access Gong via https://company-17.app.gong.io
 
 

--- a/docs/data-sources/googleads_connection.md
+++ b/docs/data-sources/googleads_connection.md
@@ -44,7 +44,6 @@ Read-Only:
 - `custom_reports` (String) Custom reports
 
     One report per line. Format is a report name:ads object:field list. e.g. myReport:ad_groups:campaign.id
-- `oauth_token_expiry` (String)
 
 <a id="nestedatt--configuration--accounts"></a>
 ### Nested Schema for `configuration.accounts`

--- a/docs/data-sources/googleanalytics_connection.md
+++ b/docs/data-sources/googleanalytics_connection.md
@@ -40,7 +40,6 @@ Read-Only:
 - `custom_reports` (String) Custom reports
 
     One report per line. Format is a report name followed by a comma-separated list of fields. e.g. myReport:field1
-- `oauth_token_expiry` (String)
 - `properties` (Attributes Set) (see [below for nested schema](#nestedatt--configuration--properties))
 - `user_email` (String) Connected user's email
 

--- a/docs/data-sources/googlesearchconsole_connection.md
+++ b/docs/data-sources/googlesearchconsole_connection.md
@@ -36,7 +36,6 @@ data "polytomic_googlesearchconsole_connection" "googlesearchconsole" {
 
 Read-Only:
 
-- `oauth_token_expiry` (String)
 - `sites` (Attributes Set) (see [below for nested schema](#nestedatt--configuration--sites))
 
 <a id="nestedatt--configuration--sites"></a>

--- a/docs/data-sources/googleslides_connection.md
+++ b/docs/data-sources/googleslides_connection.md
@@ -39,7 +39,6 @@ Read-Only:
 - `connect_mode` (String) Default: browser Valid values: <code>browser</code>, <code>jwt</code>. Default: <code>browser</code>.
 - `folder_id` (Attributes) Folder (see [below for nested schema](#nestedatt--configuration--folder_id))
 - `include_subdirectories` (Boolean) Include Subdirectories Default: <code>false</code>.
-- `oauth_token_expiry` (String)
 - `user_email` (String) Connected user's email
 
 <a id="nestedatt--configuration--folder_id"></a>

--- a/docs/data-sources/googleworkspace_connection.md
+++ b/docs/data-sources/googleworkspace_connection.md
@@ -39,6 +39,5 @@ Read-Only:
 - `auth_method` (String) Default: browser Valid values: <code>oauth</code> (OAuth), <code>service_account</code> (Service Account).
 - `client_email` (String) Connected Account
 - `customer_id` (String) Customer ID
-- `oauth_token_expiry` (String)
 
 

--- a/docs/data-sources/gsheets_connection.md
+++ b/docs/data-sources/gsheets_connection.md
@@ -38,7 +38,6 @@ Read-Only:
 
 - `connect_mode` (String) Default: browser Valid values: <code>browser</code>, <code>jwt</code>. Default: <code>browser</code>.
 - `has_headers` (Boolean) Columns have headers
-- `oauth_token_expiry` (String)
 - `spreadsheet_id` (Attributes) Spreadsheet (see [below for nested schema](#nestedatt--configuration--spreadsheet_id))
 - `user_email` (String) Connected user's email
 

--- a/docs/data-sources/linkedinads_connection.md
+++ b/docs/data-sources/linkedinads_connection.md
@@ -38,7 +38,6 @@ Read-Only:
 
 - `accounts` (Attributes Set) (see [below for nested schema](#nestedatt--configuration--accounts))
 - `connected_user` (String) Connected user
-- `oauth_token_expiry` (String)
 
 <a id="nestedatt--configuration--accounts"></a>
 ### Nested Schema for `configuration.accounts`

--- a/docs/data-sources/marketo_connection.md
+++ b/docs/data-sources/marketo_connection.md
@@ -41,7 +41,6 @@ Read-Only:
 - `daily_api_calls` (Number) Daily call limit Default: <code>37500</code>.
 - `enforce_api_limits` (Boolean) Enforce API limits
 - `include_static_lists` (Boolean) Include static list support Default: <code>true</code>.
-- `oauth_token_expiry` (String)
 - `rest_endpoint` (String) REST Endpoint
 
 

--- a/docs/data-sources/msads_connection.md
+++ b/docs/data-sources/msads_connection.md
@@ -39,7 +39,6 @@ Read-Only:
 - `accounts` (Attributes Set) (see [below for nested schema](#nestedatt--configuration--accounts))
 - `agree_customer_match_terms` (Boolean) Agree to Microsoft's [Customer Match Terms](https://help.ads.microsoft.com/#apex/ads/en/56921/1) when syncing audiences
 - `auth_method` (String) Authentication method Valid values: <code>microsoft</code> (Microsoft), <code>google</code> (Google). Default: <code>microsoft</code>.
-- `oauth_token_expiry` (String)
 - `username` (String) Connected user
 
 <a id="nestedatt--configuration--accounts"></a>

--- a/docs/data-sources/msdynamics_connection.md
+++ b/docs/data-sources/msdynamics_connection.md
@@ -37,6 +37,5 @@ data "polytomic_msdynamics_connection" "msdynamics" {
 Read-Only:
 
 - `dynamics_url` (String) Dynamics URL
-- `oauth_token_expiry` (String)
 
 

--- a/docs/data-sources/outreach_connection.md
+++ b/docs/data-sources/outreach_connection.md
@@ -37,7 +37,6 @@ data "polytomic_outreach_connection" "outreach" {
 Read-Only:
 
 - `connected_user` (String) Connected user
-- `oauth_token_expiry` (String)
 - `use_bulk_upsert` (Boolean) Use bulk API for syncing to Outreach Default: <code>true</code>.
 
 

--- a/docs/data-sources/quickbooks_connection.md
+++ b/docs/data-sources/quickbooks_connection.md
@@ -36,7 +36,6 @@ data "polytomic_quickbooks_connection" "quickbooks" {
 
 Read-Only:
 
-- `oauth_token_expiry` (String)
 - `realm_id` (String) Company ID
 
 

--- a/docs/data-sources/ramp_connection.md
+++ b/docs/data-sources/ramp_connection.md
@@ -37,6 +37,5 @@ data "polytomic_ramp_connection" "ramp" {
 Read-Only:
 
 - `is_sandbox` (Boolean) Is Sandbox
-- `oauth_token_expiry` (String)
 
 

--- a/docs/data-sources/redditads_connection.md
+++ b/docs/data-sources/redditads_connection.md
@@ -38,7 +38,6 @@ Read-Only:
 
 - `accounts` (Attributes Set) (see [below for nested schema](#nestedatt--configuration--accounts))
 - `connected_user` (String) Connected user's email
-- `oauth_token_expiry` (String)
 - `pixel_id` (String) Conversion Pixel ID
 
     Required if syncing conversion events to Reddit Ads.

--- a/docs/data-sources/sageintacct_connection.md
+++ b/docs/data-sources/sageintacct_connection.md
@@ -34,8 +34,4 @@ data "polytomic_sageintacct_connection" "sageintacct" {
 <a id="nestedatt--configuration"></a>
 ### Nested Schema for `configuration`
 
-Read-Only:
-
-- `oauth_token_expiry` (String)
-
 

--- a/docs/data-sources/salesloft_connection.md
+++ b/docs/data-sources/salesloft_connection.md
@@ -38,6 +38,5 @@ Read-Only:
 
 - `auth_method` (String) Authentication method Valid values: <code>oauth</code> (OAuth), <code>api_key</code> (API Key). Default: <code>oauth</code>.
 - `connected_user` (String) Connected user's email
-- `oauth_token_expiry` (String)
 
 

--- a/docs/data-sources/typeform_connection.md
+++ b/docs/data-sources/typeform_connection.md
@@ -34,8 +34,4 @@ data "polytomic_typeform_connection" "typeform" {
 <a id="nestedatt--configuration"></a>
 ### Nested Schema for `configuration`
 
-Read-Only:
-
-- `oauth_token_expiry` (String)
-
 

--- a/docs/data-sources/upfluence_connection.md
+++ b/docs/data-sources/upfluence_connection.md
@@ -36,7 +36,6 @@ data "polytomic_upfluence_connection" "upfluence" {
 
 Read-Only:
 
-- `oauth_token_expiry` (String)
 - `username` (String) Email
 
 

--- a/docs/data-sources/youtubeanalytics_connection.md
+++ b/docs/data-sources/youtubeanalytics_connection.md
@@ -39,7 +39,6 @@ Read-Only:
 - `content_owner_id` (String) Content owner ID
 
     If you are using a content owner account enter the content owner ID here. This is required for some reports.
-- `oauth_token_expiry` (String)
 - `user_email` (String) Connected user's email
 
 

--- a/docs/data-sources/zendesk_support_connection.md
+++ b/docs/data-sources/zendesk_support_connection.md
@@ -40,7 +40,6 @@ Read-Only:
 - `custom_api_limits` (Boolean) Enforce custom API limits
 - `domain` (String) Zendesk Subdomain
 - `email` (String)
-- `oauth_token_expiry` (String)
 - `ratelimit_rpm` (Number) Maximum requests per minute
 
     Set a custom maximum request per minute limit.

--- a/docs/data-sources/zoho_crm_connection.md
+++ b/docs/data-sources/zoho_crm_connection.md
@@ -36,7 +36,6 @@ data "polytomic_zoho_crm_connection" "zoho_crm" {
 
 Read-Only:
 
-- `oauth_token_expiry` (String)
 - `region` (String) Data center region Valid values: <code>usa</code> (USA), <code>europe</code> (Europe), <code>australia</code> (Australia), <code>canada</code> (Canada), <code>china</code> (China), <code>japan</code> (Japan), <code>saudi_arabia</code> (Saudi Arabia). Default: <code>usa</code>.
 
 

--- a/docs/guides/upgrading-to-v2.0.0.md
+++ b/docs/guides/upgrading-to-v2.0.0.md
@@ -1,0 +1,89 @@
+---
+page_title: "Upgrading to v2.0.0"
+subcategory: ""
+description: |-
+  Notes on upgrading the Polytomic provider to v2.0.0.
+---
+
+# Upgrading to v2.0.0
+
+Version 2.0.0 removes server-managed internal fields from connection configurations. These fields were never meant to be set or read through Terraform — they track internal state such as whether an OAuth flow has completed (`authenticated`) or when an OAuth token expires (`oauth_token_expiry`). Previously they were generated as `Optional` + `Computed`, so they appeared in the schema and documentation and were even assignable, despite having no effect.
+
+Unlike the server-managed fields addressed in [v1.5.0](upgrading-to-v1.5.0), which carry useful information (such as the connected user) and were made read-only, these fields carry no configuration or reference value. They are now removed entirely.
+
+This affects 28 fields across 27 connection types. Fields that are hidden in the Polytomic UI but settable through the API — such as `client_id`, `client_secret`, and `oauth_access_token` — are unchanged.
+
+## Migration steps
+
+After upgrading, run `terraform plan`.
+
+If a configuration assigns one of the removed fields, Terraform returns an error like:
+
+```
+Error: Unsupported argument
+  on main.tf line 5, in resource "polytomic_github_connection" "example":
+   5:     authenticated = true
+
+An argument named "authenticated" is not expected here.
+```
+
+Remove the assignment from your configuration. These fields were managed by Polytomic, so removing them has no effect on the connection.
+
+```hcl
+# Before (v1.5.x)
+resource "polytomic_github_connection" "example" {
+  name = "GitHub"
+  configuration = {
+    oauth_access_token = var.github_token
+    authenticated      = true # remove this line
+  }
+}
+
+# After (v2.0.0)
+resource "polytomic_github_connection" "example" {
+  name = "GitHub"
+  configuration = {
+    oauth_access_token = var.github_token
+  }
+}
+```
+
+Terraform drops the removed fields from existing state automatically on the next refresh; no manual state changes are required.
+
+If another resource or output references a removed field (for example `polytomic_github_connection.example.configuration.authenticated`), remove that reference — the value is no longer exported.
+
+## Importer
+
+If you generated your configuration with the `polytomic` importer, regenerate it with the v2.0.0 importer to drop the removed fields automatically.
+
+## Affected fields
+
+| Connection | Field(s) |
+|---|---|
+| polytomic_dbtprojectrepository_connection | oauth_token_expiry |
+| polytomic_dialpad_connection | oauth_token_expiry |
+| polytomic_dropbox_connection | oauth_token_expiry |
+| polytomic_github_connection | authenticated |
+| polytomic_gmail_connection | oauth_token_expiry |
+| polytomic_gong_connection | oauth_token_expiry |
+| polytomic_googleads_connection | oauth_token_expiry |
+| polytomic_googleanalytics_connection | oauth_token_expiry |
+| polytomic_googlesearchconsole_connection | oauth_token_expiry |
+| polytomic_googleslides_connection | oauth_token_expiry |
+| polytomic_googleworkspace_connection | oauth_token_expiry |
+| polytomic_gsheets_connection | oauth_token_expiry |
+| polytomic_linkedinads_connection | oauth_token_expiry |
+| polytomic_marketo_connection | oauth_token_expiry |
+| polytomic_msads_connection | oauth_token_expiry |
+| polytomic_msdynamics_connection | oauth_token_expiry |
+| polytomic_outreach_connection | oauth_token_expiry |
+| polytomic_quickbooks_connection | oauth_token_expiry |
+| polytomic_ramp_connection | oauth_token_expiry |
+| polytomic_redditads_connection | oauth_token_expiry |
+| polytomic_sageintacct_connection | oauth_token_expiry |
+| polytomic_salesloft_connection | oauth_token_expiry |
+| polytomic_typeform_connection | oauth_token_expiry |
+| polytomic_upfluence_connection | oauth_refresh_token, oauth_token_expiry |
+| polytomic_youtubeanalytics_connection | oauth_token_expiry |
+| polytomic_zendesk_support_connection | oauth_token_expiry |
+| polytomic_zoho_crm_connection | oauth_token_expiry |

--- a/docs/resources/dbtprojectrepository_connection.md
+++ b/docs/resources/dbtprojectrepository_connection.md
@@ -66,7 +66,6 @@ state before it will take effect on a destroy operation.
 - `branch` (String) Exposures branch
 - `latest_commit` (Attributes) Most recent exposures commit See [below for nested schema](#nestedatt--configuration--latest_commit).
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 #### Read-Only
 

--- a/docs/resources/dialpad_connection.md
+++ b/docs/resources/dialpad_connection.md
@@ -66,6 +66,5 @@ state before it will take effect on a destroy operation.
 - `application_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 

--- a/docs/resources/dropbox_connection.md
+++ b/docs/resources/dropbox_connection.md
@@ -74,7 +74,6 @@ state before it will take effect on a destroy operation.
 
     Treat the files as a single table. Default: <code>false</code>.
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 - `single_table_file_format` (String) File format Valid values: <code>csv</code> (CSV), <code>json</code> (JSON), <code>parquet</code> (Parquet). Default: <code>csv</code>.
 - `single_table_file_formats` (Set of String) File formats
 

--- a/docs/resources/github_connection.md
+++ b/docs/resources/github_connection.md
@@ -60,7 +60,6 @@ state before it will take effect on a destroy operation.
 
 #### Optional
 
-- `authenticated` (Boolean)
 - `client_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `repositories` (Attributes Set) See [below for nested schema](#nestedatt--configuration--repositories).

--- a/docs/resources/gmail_connection.md
+++ b/docs/resources/gmail_connection.md
@@ -56,7 +56,6 @@ state before it will take effect on a destroy operation.
 - `client_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 #### Read-Only
 

--- a/docs/resources/gong_connection.md
+++ b/docs/resources/gong_connection.md
@@ -66,7 +66,6 @@ state before it will take effect on a destroy operation.
 - `client_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 - `subdomain` (String) Gong subdomain i.e. company-17 if you access Gong via https://company-17.app.gong.io
 
 

--- a/docs/resources/googleads_connection.md
+++ b/docs/resources/googleads_connection.md
@@ -66,7 +66,6 @@ state before it will take effect on a destroy operation.
 
     One report per line. Format is a report name:ads object:field list. e.g. myReport:ad_groups:campaign.id
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 #### Read-Only
 

--- a/docs/resources/googleanalytics_connection.md
+++ b/docs/resources/googleanalytics_connection.md
@@ -66,7 +66,6 @@ state before it will take effect on a destroy operation.
 
     One report per line. Format is a report name followed by a comma-separated list of fields. e.g. myReport:field1
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 - `properties` (Attributes Set) See [below for nested schema](#nestedatt--configuration--properties).
 - `service_account` (String, Sensitive) Service account key
 

--- a/docs/resources/googlesearchconsole_connection.md
+++ b/docs/resources/googlesearchconsole_connection.md
@@ -56,7 +56,6 @@ state before it will take effect on a destroy operation.
 - `client_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 - `sites` (Attributes Set) See [below for nested schema](#nestedatt--configuration--sites).
 
 

--- a/docs/resources/googleslides_connection.md
+++ b/docs/resources/googleslides_connection.md
@@ -65,7 +65,6 @@ state before it will take effect on a destroy operation.
 - `connect_mode` (String) Default: browser Valid values: <code>browser</code>, <code>jwt</code>. Default: <code>browser</code>.
 - `include_subdirectories` (Boolean) Include Subdirectories Default: <code>false</code>.
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 - `service_account` (String, Sensitive) Service account key
 
 #### Read-Only

--- a/docs/resources/googleworkspace_connection.md
+++ b/docs/resources/googleworkspace_connection.md
@@ -59,7 +59,6 @@ state before it will take effect on a destroy operation.
 - `client_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `customer_id` (String) Customer ID
-- `oauth_token_expiry` (String)
 - `service_account` (String, Sensitive) Service account key
 
 #### Read-Only

--- a/docs/resources/gsheets_connection.md
+++ b/docs/resources/gsheets_connection.md
@@ -65,7 +65,6 @@ state before it will take effect on a destroy operation.
 - `connect_mode` (String) Default: browser Valid values: <code>browser</code>, <code>jwt</code>. Default: <code>browser</code>.
 - `has_headers` (Boolean) Columns have headers
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 - `service_account` (String, Sensitive) Service account key
 
 #### Read-Only

--- a/docs/resources/linkedinads_connection.md
+++ b/docs/resources/linkedinads_connection.md
@@ -60,7 +60,6 @@ state before it will take effect on a destroy operation.
 - `client_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 #### Read-Only
 

--- a/docs/resources/marketo_connection.md
+++ b/docs/resources/marketo_connection.md
@@ -66,6 +66,5 @@ state before it will take effect on a destroy operation.
 - `daily_api_calls` (Number) Daily call limit Default: <code>37500</code>.
 - `enforce_api_limits` (Boolean) Enforce API limits
 - `include_static_lists` (Boolean) Include static list support Default: <code>true</code>.
-- `oauth_token_expiry` (String)
 
 

--- a/docs/resources/msads_connection.md
+++ b/docs/resources/msads_connection.md
@@ -62,7 +62,6 @@ state before it will take effect on a destroy operation.
 - `client_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 #### Read-Only
 

--- a/docs/resources/msdynamics_connection.md
+++ b/docs/resources/msdynamics_connection.md
@@ -63,6 +63,5 @@ state before it will take effect on a destroy operation.
 - `client_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 

--- a/docs/resources/outreach_connection.md
+++ b/docs/resources/outreach_connection.md
@@ -59,7 +59,6 @@ state before it will take effect on a destroy operation.
 - `client_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 - `use_bulk_upsert` (Boolean) Use bulk API for syncing to Outreach Default: <code>true</code>.
 
 #### Read-Only

--- a/docs/resources/quickbooks_connection.md
+++ b/docs/resources/quickbooks_connection.md
@@ -64,6 +64,5 @@ state before it will take effect on a destroy operation.
 - `client_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 

--- a/docs/resources/ramp_connection.md
+++ b/docs/resources/ramp_connection.md
@@ -60,6 +60,5 @@ state before it will take effect on a destroy operation.
 - `client_secret` (String, Sensitive)
 - `is_sandbox` (Boolean) Is Sandbox
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 

--- a/docs/resources/redditads_connection.md
+++ b/docs/resources/redditads_connection.md
@@ -60,7 +60,6 @@ state before it will take effect on a destroy operation.
 - `application_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 - `pixel_id` (String) Conversion Pixel ID
 
     Required if syncing conversion events to Reddit Ads.

--- a/docs/resources/sageintacct_connection.md
+++ b/docs/resources/sageintacct_connection.md
@@ -59,6 +59,5 @@ state before it will take effect on a destroy operation.
 - `application_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 

--- a/docs/resources/salesloft_connection.md
+++ b/docs/resources/salesloft_connection.md
@@ -64,7 +64,6 @@ state before it will take effect on a destroy operation.
 - `application_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 #### Read-Only
 

--- a/docs/resources/typeform_connection.md
+++ b/docs/resources/typeform_connection.md
@@ -59,6 +59,5 @@ state before it will take effect on a destroy operation.
 - `application_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 

--- a/docs/resources/upfluence_connection.md
+++ b/docs/resources/upfluence_connection.md
@@ -56,9 +56,4 @@ state before it will take effect on a destroy operation.
 - `password` (String, Sensitive)
 - `username` (String) Email
 
-#### Optional
-
-- `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
-
 

--- a/docs/resources/youtubeanalytics_connection.md
+++ b/docs/resources/youtubeanalytics_connection.md
@@ -62,7 +62,6 @@ state before it will take effect on a destroy operation.
 
     If you are using a content owner account enter the content owner ID here. This is required for some reports.
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 #### Read-Only
 

--- a/docs/resources/zendesk_support_connection.md
+++ b/docs/resources/zendesk_support_connection.md
@@ -67,7 +67,6 @@ state before it will take effect on a destroy operation.
 - `custom_api_limits` (Boolean) Enforce custom API limits
 - `email` (String)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 - `ratelimit_rpm` (Number) Maximum requests per minute
 
     Set a custom maximum request per minute limit.

--- a/docs/resources/zoho_crm_connection.md
+++ b/docs/resources/zoho_crm_connection.md
@@ -59,6 +59,5 @@ state before it will take effect on a destroy operation.
 
 - `client_id` (String, Sensitive) Client ID
 - `client_secret` (String, Sensitive) Client secret
-- `oauth_token_expiry` (String)
 
 

--- a/provider/gen/connections/connections.go
+++ b/provider/gen/connections/connections.go
@@ -505,6 +505,9 @@ func attributesForJSONSchema(connSchema *jsonschema.Schema) ([]Attribute, error)
 	// dependentSchemas doesn't introduce duplicates and conditions merge.
 	seen := map[string]int{}
 	for pair := connSchema.Properties.Oldest(); pair != nil; pair = pair.Next() {
+		if isInternalHidden(pair.Value) {
+			continue
+		}
 		attr, err := tfAttr(pair.Key, pair.Value, connSchema.Required)
 		if err != nil {
 			return attrs, err
@@ -619,6 +622,9 @@ func extractConditionalAttrs(triggerField string, schema *jsonschema.Schema) ([]
 				if pair.Key == triggerField {
 					continue
 				}
+				if isInternalHidden(pair.Value) {
+					continue
+				}
 				attr, err := tfAttr(pair.Key, pair.Value, branch.Required)
 				if err != nil {
 					return nil, err
@@ -682,6 +688,9 @@ func extractIfThenAttrs(triggerField string, ifSchema, thenSchema *jsonschema.Sc
 			if pair.Key == triggerField {
 				continue
 			}
+			if isInternalHidden(pair.Value) {
+				continue
+			}
 			attr, err := tfAttr(pair.Key, pair.Value, thenSchema.Required)
 			if err != nil {
 				return nil, err
@@ -708,6 +717,22 @@ func extractIfThenAttrs(triggerField string, ifSchema, thenSchema *jsonschema.Sc
 	}
 
 	return attrs, nil
+}
+
+// isInternalHidden reports whether a property is server-managed internal state
+// that should not be surfaced in Terraform: the backend marks it hidden in the
+// UI AND it is not settable via the API (no api_field marker). Examples include
+// github `authenticated`, `oauth_token_expiry`, and upfluence
+// `oauth_refresh_token`. Fields that are hidden but api_field=true (client_id,
+// client_secret, oauth_access_token) are legitimate connection inputs and are
+// kept. The same field name may be api_field in one backend and internal in
+// another, so this decision must be made per-field from these flags rather than
+// from a name blocklist.
+func isInternalHidden(s *jsonschema.Schema) bool {
+	if s == nil {
+		return false
+	}
+	return s.Extras["hidden"] == true && s.Extras["api_field"] != true
 }
 
 func tfAttr(k string, a *jsonschema.Schema, required []string) (Attribute, error) {

--- a/provider/gen/connections/connections_test.go
+++ b/provider/gen/connections/connections_test.go
@@ -242,3 +242,94 @@ func TestTfAttr(t *testing.T) {
 		assert.Equal(t, "schema.StringAttribute", nameAttr.AttrType)
 	})
 }
+
+func TestIsInternalHidden(t *testing.T) {
+	cases := []struct {
+		name  string
+		extra map[string]interface{}
+		want  bool
+	}{
+		{"hidden without api_field is internal", map[string]interface{}{"hidden": true}, true},
+		{"hidden with api_field is kept", map[string]interface{}{"hidden": true, "api_field": true}, false},
+		{"api_field without hidden is kept", map[string]interface{}{"api_field": true}, false},
+		{"no markers is kept", nil, false},
+		{"sensitive only is kept", map[string]interface{}{"sensitive": true}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isInternalHidden(&jsonschema.Schema{Extras: tc.extra}))
+		})
+	}
+
+	t.Run("nil schema is not internal", func(t *testing.T) {
+		assert.False(t, isInternalHidden(nil))
+	})
+}
+
+func TestAttributesForJSONSchemaFiltersInternalHidden(t *testing.T) {
+	t.Run("top-level properties", func(t *testing.T) {
+		props := jsonschema.NewProperties()
+		// Server-managed internal state: hidden, not settable via API. Dropped.
+		props.Set("authenticated", &jsonschema.Schema{
+			Type:   "boolean",
+			Extras: map[string]interface{}{"hidden": true},
+		})
+		props.Set("oauth_token_expiry", &jsonschema.Schema{
+			Type:   "string",
+			Extras: map[string]interface{}{"hidden": true},
+		})
+		// Hidden but settable via API (UI hides it behind an OAuth button). Kept.
+		props.Set("client_secret", &jsonschema.Schema{
+			Type:   "string",
+			Extras: map[string]interface{}{"hidden": true, "api_field": true},
+		})
+		// Ordinary field. Kept.
+		props.Set("repositories", &jsonschema.Schema{Type: "array", Items: &jsonschema.Schema{Type: "string"}})
+
+		attrs, err := attributesForJSONSchema(&jsonschema.Schema{
+			Type:       "object",
+			Properties: props,
+		})
+		require.NoError(t, err)
+
+		names := map[string]bool{}
+		for _, a := range attrs {
+			names[a.Name] = true
+		}
+		assert.NotContains(t, names, "authenticated")
+		assert.NotContains(t, names, "oauth_token_expiry")
+		assert.Contains(t, names, "client_secret")
+		assert.Contains(t, names, "repositories")
+	})
+
+	t.Run("conditional (dependentSchemas) properties", func(t *testing.T) {
+		props := jsonschema.NewProperties()
+		props.Set("auth_mode", &jsonschema.Schema{Type: "string", Enum: []interface{}{"oauth"}})
+
+		branchProps := jsonschema.NewProperties()
+		branchProps.Set("auth_mode", &jsonschema.Schema{Enum: []interface{}{"oauth"}})
+		branchProps.Set("oauth_refresh_token", &jsonschema.Schema{
+			Type:   "string",
+			Extras: map[string]interface{}{"hidden": true},
+		})
+		branchProps.Set("scope", &jsonschema.Schema{Type: "string"})
+
+		attrs, err := attributesForJSONSchema(&jsonschema.Schema{
+			Type:       "object",
+			Properties: props,
+			DependentSchemas: map[string]*jsonschema.Schema{
+				"auth_mode": {
+					OneOf: []*jsonschema.Schema{{Properties: branchProps}},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		names := map[string]bool{}
+		for _, a := range attrs {
+			names[a.Name] = true
+		}
+		assert.NotContains(t, names, "oauth_refresh_token")
+		assert.Contains(t, names, "scope")
+	})
+}

--- a/provider/internal/connections/datasource_dbtprojectrepository_connection.go
+++ b/provider/internal/connections/datasource_dbtprojectrepository_connection.go
@@ -77,10 +77,6 @@ func (d *DbtprojectrepositoryConnectionDataSource) Schema(ctx context.Context, r
 							},
 						},
 					},
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 					"repository": schema.StringAttribute{
 						MarkdownDescription: `dbt project repository
 
@@ -102,8 +98,7 @@ type DbtprojectrepositoryDataSourceConf struct {
 		Href string `mapstructure:"href" tfsdk:"href"`
 		Text string `mapstructure:"text" tfsdk:"text"`
 	} `mapstructure:"latest_commit" tfsdk:"latest_commit"`
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
-	Repository         string `mapstructure:"repository" tfsdk:"repository"`
+	Repository string `mapstructure:"repository" tfsdk:"repository"`
 }
 
 func (d *DbtprojectrepositoryConnectionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -149,8 +144,7 @@ func (d *DbtprojectrepositoryConnectionDataSource) Read(ctx context.Context, req
 				"href": types.StringType,
 				"text": types.StringType,
 			},
-		}, "oauth_token_expiry": types.StringType,
-		"repository": types.StringType,
+		}, "repository": types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/datasource_dialpad_connection.go
+++ b/provider/internal/connections/datasource_dialpad_connection.go
@@ -55,10 +55,6 @@ func (d *DialpadConnectionDataSource) Schema(ctx context.Context, req datasource
 						MarkdownDescription: `Authentication method Valid values: <code>api_key</code> (API Key), <code>oauth</code> (OAuth). Default: <code>api_key</code>.`,
 						Computed:            true,
 					},
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 				},
 				Optional: true,
 			},
@@ -67,8 +63,7 @@ func (d *DialpadConnectionDataSource) Schema(ctx context.Context, req datasource
 }
 
 type DialpadDataSourceConf struct {
-	Auth_method        string `mapstructure:"auth_method" tfsdk:"auth_method"`
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
+	Auth_method string `mapstructure:"auth_method" tfsdk:"auth_method"`
 }
 
 func (d *DialpadConnectionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -106,8 +101,7 @@ func (d *DialpadConnectionDataSource) Read(ctx context.Context, req datasource.R
 
 	var diags diag.Diagnostics
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"auth_method":        types.StringType,
-		"oauth_token_expiry": types.StringType,
+		"auth_method": types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/datasource_dropbox_connection.go
+++ b/provider/internal/connections/datasource_dropbox_connection.go
@@ -75,10 +75,6 @@ func (d *DropboxConnectionDataSource) Schema(ctx context.Context, req datasource
     Treat the files as a single table. Default: <code>false</code>.`,
 						Computed: true,
 					},
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 					"single_table_file_format": schema.StringAttribute{
 						MarkdownDescription: `File format Valid values: <code>csv</code> (CSV), <code>json</code> (JSON), <code>parquet</code> (Parquet). Default: <code>csv</code>.`,
 						Computed:            true,
@@ -113,7 +109,6 @@ type DropboxDataSourceConf struct {
 	Directory_glob_pattern    string   `mapstructure:"directory_glob_pattern" tfsdk:"directory_glob_pattern"`
 	Is_directory_snapshot     bool     `mapstructure:"is_directory_snapshot" tfsdk:"is_directory_snapshot"`
 	Is_single_table           bool     `mapstructure:"is_single_table" tfsdk:"is_single_table"`
-	Oauth_token_expiry        string   `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 	Single_table_file_format  string   `mapstructure:"single_table_file_format" tfsdk:"single_table_file_format"`
 	Single_table_file_formats []string `mapstructure:"single_table_file_formats" tfsdk:"single_table_file_formats"`
 	Single_table_name         string   `mapstructure:"single_table_name" tfsdk:"single_table_name"`
@@ -160,7 +155,6 @@ func (d *DropboxConnectionDataSource) Read(ctx context.Context, req datasource.R
 		"directory_glob_pattern":   types.StringType,
 		"is_directory_snapshot":    types.BoolType,
 		"is_single_table":          types.BoolType,
-		"oauth_token_expiry":       types.StringType,
 		"single_table_file_format": types.StringType,
 		"single_table_file_formats": types.SetType{
 			ElemType: types.StringType,

--- a/provider/internal/connections/datasource_github_connection.go
+++ b/provider/internal/connections/datasource_github_connection.go
@@ -51,10 +51,6 @@ func (d *GithubConnectionDataSource) Schema(ctx context.Context, req datasource.
 			},
 			"configuration": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
-					"authenticated": schema.BoolAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 					"repositories": schema.SetNestedAttribute{
 						MarkdownDescription: ``,
 						Computed:            true,
@@ -79,8 +75,7 @@ func (d *GithubConnectionDataSource) Schema(ctx context.Context, req datasource.
 }
 
 type GithubDataSourceConf struct {
-	Authenticated bool `mapstructure:"authenticated" tfsdk:"authenticated"`
-	Repositories  []struct {
+	Repositories []struct {
 		Label string `mapstructure:"label" tfsdk:"label"`
 		Value string `mapstructure:"value" tfsdk:"value"`
 	} `mapstructure:"repositories" tfsdk:"repositories"`
@@ -121,7 +116,6 @@ func (d *GithubConnectionDataSource) Read(ctx context.Context, req datasource.Re
 
 	var diags diag.Diagnostics
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"authenticated": types.BoolType,
 		"repositories": types.SetType{
 			ElemType: types.ObjectType{
 				AttrTypes: map[string]attr.Type{

--- a/provider/internal/connections/datasource_gmail_connection.go
+++ b/provider/internal/connections/datasource_gmail_connection.go
@@ -51,10 +51,6 @@ func (d *GmailConnectionDataSource) Schema(ctx context.Context, req datasource.S
 			},
 			"configuration": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 					"user_email": schema.StringAttribute{
 						MarkdownDescription: `Connected user's email`,
 						Computed:            true,
@@ -67,8 +63,7 @@ func (d *GmailConnectionDataSource) Schema(ctx context.Context, req datasource.S
 }
 
 type GmailDataSourceConf struct {
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
-	User_email         string `mapstructure:"user_email" tfsdk:"user_email"`
+	User_email string `mapstructure:"user_email" tfsdk:"user_email"`
 }
 
 func (d *GmailConnectionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -106,8 +101,7 @@ func (d *GmailConnectionDataSource) Read(ctx context.Context, req datasource.Rea
 
 	var diags diag.Diagnostics
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"oauth_token_expiry": types.StringType,
-		"user_email":         types.StringType,
+		"user_email": types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/datasource_gong_connection.go
+++ b/provider/internal/connections/datasource_gong_connection.go
@@ -59,10 +59,6 @@ func (d *GongConnectionDataSource) Schema(ctx context.Context, req datasource.Sc
 						MarkdownDescription: `Authentication method Valid values: <code>token</code> (Access key and secret), <code>oauth</code> (OAuth). Default: <code>token</code>.`,
 						Computed:            true,
 					},
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 					"subdomain": schema.StringAttribute{
 						MarkdownDescription: `Gong subdomain i.e. company-17 if you access Gong via https://company-17.app.gong.io`,
 						Computed:            true,
@@ -75,10 +71,9 @@ func (d *GongConnectionDataSource) Schema(ctx context.Context, req datasource.Sc
 }
 
 type GongDataSourceConf struct {
-	Access_key         string `mapstructure:"access_key" tfsdk:"access_key"`
-	Auth_method        string `mapstructure:"auth_method" tfsdk:"auth_method"`
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
-	Subdomain          string `mapstructure:"subdomain" tfsdk:"subdomain"`
+	Access_key  string `mapstructure:"access_key" tfsdk:"access_key"`
+	Auth_method string `mapstructure:"auth_method" tfsdk:"auth_method"`
+	Subdomain   string `mapstructure:"subdomain" tfsdk:"subdomain"`
 }
 
 func (d *GongConnectionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -116,10 +111,9 @@ func (d *GongConnectionDataSource) Read(ctx context.Context, req datasource.Read
 
 	var diags diag.Diagnostics
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"access_key":         types.StringType,
-		"auth_method":        types.StringType,
-		"oauth_token_expiry": types.StringType,
-		"subdomain":          types.StringType,
+		"access_key":  types.StringType,
+		"auth_method": types.StringType,
+		"subdomain":   types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/datasource_googleads_connection.go
+++ b/provider/internal/connections/datasource_googleads_connection.go
@@ -83,10 +83,6 @@ func (d *GoogleadsConnectionDataSource) Schema(ctx context.Context, req datasour
     One report per line. Format is a report name:ads object:field list. e.g. myReport:ad_groups:campaign.id`,
 						Computed: true,
 					},
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 				},
 				Optional: true,
 			},
@@ -102,7 +98,6 @@ type GoogleadsDataSourceConf struct {
 	Blanket_user_consent bool   `mapstructure:"blanket_user_consent" tfsdk:"blanket_user_consent"`
 	Connected_user       string `mapstructure:"connected_user" tfsdk:"connected_user"`
 	Custom_reports       string `mapstructure:"custom_reports" tfsdk:"custom_reports"`
-	Oauth_token_expiry   string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 }
 
 func (d *GoogleadsConnectionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -151,7 +146,6 @@ func (d *GoogleadsConnectionDataSource) Read(ctx context.Context, req datasource
 		"blanket_user_consent": types.BoolType,
 		"connected_user":       types.StringType,
 		"custom_reports":       types.StringType,
-		"oauth_token_expiry":   types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/datasource_googleanalytics_connection.go
+++ b/provider/internal/connections/datasource_googleanalytics_connection.go
@@ -61,10 +61,6 @@ func (d *GoogleanalyticsConnectionDataSource) Schema(ctx context.Context, req da
     One report per line. Format is a report name followed by a comma-separated list of fields. e.g. myReport:field1`,
 						Computed: true,
 					},
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 					"properties": schema.SetNestedAttribute{
 						MarkdownDescription: ``,
 						Computed:            true,
@@ -93,10 +89,9 @@ func (d *GoogleanalyticsConnectionDataSource) Schema(ctx context.Context, req da
 }
 
 type GoogleanalyticsDataSourceConf struct {
-	Auth_method        string `mapstructure:"auth_method" tfsdk:"auth_method"`
-	Custom_reports     string `mapstructure:"custom_reports" tfsdk:"custom_reports"`
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
-	Properties         []struct {
+	Auth_method    string `mapstructure:"auth_method" tfsdk:"auth_method"`
+	Custom_reports string `mapstructure:"custom_reports" tfsdk:"custom_reports"`
+	Properties     []struct {
 		Label string `mapstructure:"label" tfsdk:"label"`
 		Value string `mapstructure:"value" tfsdk:"value"`
 	} `mapstructure:"properties" tfsdk:"properties"`
@@ -138,9 +133,8 @@ func (d *GoogleanalyticsConnectionDataSource) Read(ctx context.Context, req data
 
 	var diags diag.Diagnostics
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"auth_method":        types.StringType,
-		"custom_reports":     types.StringType,
-		"oauth_token_expiry": types.StringType,
+		"auth_method":    types.StringType,
+		"custom_reports": types.StringType,
 		"properties": types.SetType{
 			ElemType: types.ObjectType{
 				AttrTypes: map[string]attr.Type{

--- a/provider/internal/connections/datasource_googlesearchconsole_connection.go
+++ b/provider/internal/connections/datasource_googlesearchconsole_connection.go
@@ -51,10 +51,6 @@ func (d *GooglesearchconsoleConnectionDataSource) Schema(ctx context.Context, re
 			},
 			"configuration": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 					"sites": schema.SetNestedAttribute{
 						MarkdownDescription: ``,
 						Computed:            true,
@@ -79,8 +75,7 @@ func (d *GooglesearchconsoleConnectionDataSource) Schema(ctx context.Context, re
 }
 
 type GooglesearchconsoleDataSourceConf struct {
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
-	Sites              []struct {
+	Sites []struct {
 		Label string `mapstructure:"label" tfsdk:"label"`
 		Value string `mapstructure:"value" tfsdk:"value"`
 	} `mapstructure:"sites" tfsdk:"sites"`
@@ -121,7 +116,6 @@ func (d *GooglesearchconsoleConnectionDataSource) Read(ctx context.Context, req 
 
 	var diags diag.Diagnostics
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"oauth_token_expiry": types.StringType,
 		"sites": types.SetType{
 			ElemType: types.ObjectType{
 				AttrTypes: map[string]attr.Type{

--- a/provider/internal/connections/datasource_googleslides_connection.go
+++ b/provider/internal/connections/datasource_googleslides_connection.go
@@ -73,10 +73,6 @@ func (d *GoogleslidesConnectionDataSource) Schema(ctx context.Context, req datas
 						MarkdownDescription: `Include Subdirectories Default: <code>false</code>.`,
 						Computed:            true,
 					},
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 					"user_email": schema.StringAttribute{
 						MarkdownDescription: `Connected user's email`,
 						Computed:            true,
@@ -95,7 +91,6 @@ type GoogleslidesDataSourceConf struct {
 		Value string `mapstructure:"value" tfsdk:"value"`
 	} `mapstructure:"folder_id" tfsdk:"folder_id"`
 	Include_subdirectories bool   `mapstructure:"include_subdirectories" tfsdk:"include_subdirectories"`
-	Oauth_token_expiry     string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 	User_email             string `mapstructure:"user_email" tfsdk:"user_email"`
 }
 
@@ -141,8 +136,7 @@ func (d *GoogleslidesConnectionDataSource) Read(ctx context.Context, req datasou
 				"value": types.StringType,
 			},
 		}, "include_subdirectories": types.BoolType,
-		"oauth_token_expiry": types.StringType,
-		"user_email":         types.StringType,
+		"user_email": types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/datasource_googleworkspace_connection.go
+++ b/provider/internal/connections/datasource_googleworkspace_connection.go
@@ -63,10 +63,6 @@ func (d *GoogleworkspaceConnectionDataSource) Schema(ctx context.Context, req da
 						MarkdownDescription: `Customer ID`,
 						Computed:            true,
 					},
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 				},
 				Optional: true,
 			},
@@ -75,10 +71,9 @@ func (d *GoogleworkspaceConnectionDataSource) Schema(ctx context.Context, req da
 }
 
 type GoogleworkspaceDataSourceConf struct {
-	Auth_method        string `mapstructure:"auth_method" tfsdk:"auth_method"`
-	Client_email       string `mapstructure:"client_email" tfsdk:"client_email"`
-	Customer_id        string `mapstructure:"customer_id" tfsdk:"customer_id"`
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
+	Auth_method  string `mapstructure:"auth_method" tfsdk:"auth_method"`
+	Client_email string `mapstructure:"client_email" tfsdk:"client_email"`
+	Customer_id  string `mapstructure:"customer_id" tfsdk:"customer_id"`
 }
 
 func (d *GoogleworkspaceConnectionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -116,10 +111,9 @@ func (d *GoogleworkspaceConnectionDataSource) Read(ctx context.Context, req data
 
 	var diags diag.Diagnostics
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"auth_method":        types.StringType,
-		"client_email":       types.StringType,
-		"customer_id":        types.StringType,
-		"oauth_token_expiry": types.StringType,
+		"auth_method":  types.StringType,
+		"client_email": types.StringType,
+		"customer_id":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/datasource_gsheets_connection.go
+++ b/provider/internal/connections/datasource_gsheets_connection.go
@@ -59,10 +59,6 @@ func (d *GsheetsConnectionDataSource) Schema(ctx context.Context, req datasource
 						MarkdownDescription: `Columns have headers`,
 						Computed:            true,
 					},
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 					"spreadsheet_id": schema.SingleNestedAttribute{
 						MarkdownDescription: `Spreadsheet`,
 						Computed:            true,
@@ -89,10 +85,9 @@ func (d *GsheetsConnectionDataSource) Schema(ctx context.Context, req datasource
 }
 
 type GsheetsDataSourceConf struct {
-	Connect_mode       string `mapstructure:"connect_mode" tfsdk:"connect_mode"`
-	Has_headers        bool   `mapstructure:"has_headers" tfsdk:"has_headers"`
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
-	Spreadsheet_id     struct {
+	Connect_mode   string `mapstructure:"connect_mode" tfsdk:"connect_mode"`
+	Has_headers    bool   `mapstructure:"has_headers" tfsdk:"has_headers"`
+	Spreadsheet_id struct {
 		Label string `mapstructure:"label" tfsdk:"label"`
 		Value string `mapstructure:"value" tfsdk:"value"`
 	} `mapstructure:"spreadsheet_id" tfsdk:"spreadsheet_id"`
@@ -134,9 +129,8 @@ func (d *GsheetsConnectionDataSource) Read(ctx context.Context, req datasource.R
 
 	var diags diag.Diagnostics
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"connect_mode":       types.StringType,
-		"has_headers":        types.BoolType,
-		"oauth_token_expiry": types.StringType,
+		"connect_mode": types.StringType,
+		"has_headers":  types.BoolType,
 		"spreadsheet_id": types.ObjectType{
 			AttrTypes: map[string]attr.Type{
 				"label": types.StringType,

--- a/provider/internal/connections/datasource_linkedinads_connection.go
+++ b/provider/internal/connections/datasource_linkedinads_connection.go
@@ -71,10 +71,6 @@ func (d *LinkedinadsConnectionDataSource) Schema(ctx context.Context, req dataso
 						MarkdownDescription: `Connected user`,
 						Computed:            true,
 					},
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 				},
 				Optional: true,
 			},
@@ -87,8 +83,7 @@ type LinkedinadsDataSourceConf struct {
 		Label string `mapstructure:"label" tfsdk:"label"`
 		Value string `mapstructure:"value" tfsdk:"value"`
 	} `mapstructure:"accounts" tfsdk:"accounts"`
-	Connected_user     string `mapstructure:"connected_user" tfsdk:"connected_user"`
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
+	Connected_user string `mapstructure:"connected_user" tfsdk:"connected_user"`
 }
 
 func (d *LinkedinadsConnectionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -134,8 +129,7 @@ func (d *LinkedinadsConnectionDataSource) Read(ctx context.Context, req datasour
 				},
 			},
 		},
-		"connected_user":     types.StringType,
-		"oauth_token_expiry": types.StringType,
+		"connected_user": types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/datasource_marketo_connection.go
+++ b/provider/internal/connections/datasource_marketo_connection.go
@@ -71,10 +71,6 @@ func (d *MarketoConnectionDataSource) Schema(ctx context.Context, req datasource
 						MarkdownDescription: `Include static list support Default: <code>true</code>.`,
 						Computed:            true,
 					},
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 					"rest_endpoint": schema.StringAttribute{
 						MarkdownDescription: `REST Endpoint`,
 						Computed:            true,
@@ -92,7 +88,6 @@ type MarketoDataSourceConf struct {
 	Daily_api_calls      int64  `mapstructure:"daily_api_calls" tfsdk:"daily_api_calls"`
 	Enforce_api_limits   bool   `mapstructure:"enforce_api_limits" tfsdk:"enforce_api_limits"`
 	Include_static_lists bool   `mapstructure:"include_static_lists" tfsdk:"include_static_lists"`
-	Oauth_token_expiry   string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 	Rest_endpoint        string `mapstructure:"rest_endpoint" tfsdk:"rest_endpoint"`
 }
 
@@ -136,7 +131,6 @@ func (d *MarketoConnectionDataSource) Read(ctx context.Context, req datasource.R
 		"daily_api_calls":      types.NumberType,
 		"enforce_api_limits":   types.BoolType,
 		"include_static_lists": types.BoolType,
-		"oauth_token_expiry":   types.StringType,
 		"rest_endpoint":        types.StringType,
 	}, conf)
 	if diags.HasError() {

--- a/provider/internal/connections/datasource_msads_connection.go
+++ b/provider/internal/connections/datasource_msads_connection.go
@@ -75,10 +75,6 @@ func (d *MsadsConnectionDataSource) Schema(ctx context.Context, req datasource.S
 						MarkdownDescription: `Authentication method Valid values: <code>microsoft</code> (Microsoft), <code>google</code> (Google). Default: <code>microsoft</code>.`,
 						Computed:            true,
 					},
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 					"username": schema.StringAttribute{
 						MarkdownDescription: `Connected user`,
 						Computed:            true,
@@ -97,7 +93,6 @@ type MsadsDataSourceConf struct {
 	} `mapstructure:"accounts" tfsdk:"accounts"`
 	Agree_customer_match_terms bool   `mapstructure:"agree_customer_match_terms" tfsdk:"agree_customer_match_terms"`
 	Auth_method                string `mapstructure:"auth_method" tfsdk:"auth_method"`
-	Oauth_token_expiry         string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 	Username                   string `mapstructure:"username" tfsdk:"username"`
 }
 
@@ -146,7 +141,6 @@ func (d *MsadsConnectionDataSource) Read(ctx context.Context, req datasource.Rea
 		},
 		"agree_customer_match_terms": types.BoolType,
 		"auth_method":                types.StringType,
-		"oauth_token_expiry":         types.StringType,
 		"username":                   types.StringType,
 	}, conf)
 	if diags.HasError() {

--- a/provider/internal/connections/datasource_msdynamics_connection.go
+++ b/provider/internal/connections/datasource_msdynamics_connection.go
@@ -55,10 +55,6 @@ func (d *MsdynamicsConnectionDataSource) Schema(ctx context.Context, req datasou
 						MarkdownDescription: `Dynamics URL`,
 						Computed:            true,
 					},
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 				},
 				Optional: true,
 			},
@@ -67,8 +63,7 @@ func (d *MsdynamicsConnectionDataSource) Schema(ctx context.Context, req datasou
 }
 
 type MsdynamicsDataSourceConf struct {
-	Dynamics_url       string `mapstructure:"dynamics_url" tfsdk:"dynamics_url"`
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
+	Dynamics_url string `mapstructure:"dynamics_url" tfsdk:"dynamics_url"`
 }
 
 func (d *MsdynamicsConnectionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -106,8 +101,7 @@ func (d *MsdynamicsConnectionDataSource) Read(ctx context.Context, req datasourc
 
 	var diags diag.Diagnostics
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"dynamics_url":       types.StringType,
-		"oauth_token_expiry": types.StringType,
+		"dynamics_url": types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/datasource_outreach_connection.go
+++ b/provider/internal/connections/datasource_outreach_connection.go
@@ -55,10 +55,6 @@ func (d *OutreachConnectionDataSource) Schema(ctx context.Context, req datasourc
 						MarkdownDescription: `Connected user`,
 						Computed:            true,
 					},
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 					"use_bulk_upsert": schema.BoolAttribute{
 						MarkdownDescription: `Use bulk API for syncing to Outreach Default: <code>true</code>.`,
 						Computed:            true,
@@ -71,9 +67,8 @@ func (d *OutreachConnectionDataSource) Schema(ctx context.Context, req datasourc
 }
 
 type OutreachDataSourceConf struct {
-	Connected_user     string `mapstructure:"connected_user" tfsdk:"connected_user"`
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
-	Use_bulk_upsert    bool   `mapstructure:"use_bulk_upsert" tfsdk:"use_bulk_upsert"`
+	Connected_user  string `mapstructure:"connected_user" tfsdk:"connected_user"`
+	Use_bulk_upsert bool   `mapstructure:"use_bulk_upsert" tfsdk:"use_bulk_upsert"`
 }
 
 func (d *OutreachConnectionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -111,9 +106,8 @@ func (d *OutreachConnectionDataSource) Read(ctx context.Context, req datasource.
 
 	var diags diag.Diagnostics
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"connected_user":     types.StringType,
-		"oauth_token_expiry": types.StringType,
-		"use_bulk_upsert":    types.BoolType,
+		"connected_user":  types.StringType,
+		"use_bulk_upsert": types.BoolType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/datasource_quickbooks_connection.go
+++ b/provider/internal/connections/datasource_quickbooks_connection.go
@@ -51,10 +51,6 @@ func (d *QuickbooksConnectionDataSource) Schema(ctx context.Context, req datasou
 			},
 			"configuration": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 					"realm_id": schema.StringAttribute{
 						MarkdownDescription: `Company ID`,
 						Computed:            true,
@@ -67,8 +63,7 @@ func (d *QuickbooksConnectionDataSource) Schema(ctx context.Context, req datasou
 }
 
 type QuickbooksDataSourceConf struct {
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
-	Realm_id           string `mapstructure:"realm_id" tfsdk:"realm_id"`
+	Realm_id string `mapstructure:"realm_id" tfsdk:"realm_id"`
 }
 
 func (d *QuickbooksConnectionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -106,8 +101,7 @@ func (d *QuickbooksConnectionDataSource) Read(ctx context.Context, req datasourc
 
 	var diags diag.Diagnostics
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"oauth_token_expiry": types.StringType,
-		"realm_id":           types.StringType,
+		"realm_id": types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/datasource_ramp_connection.go
+++ b/provider/internal/connections/datasource_ramp_connection.go
@@ -55,10 +55,6 @@ func (d *RampConnectionDataSource) Schema(ctx context.Context, req datasource.Sc
 						MarkdownDescription: `Is Sandbox`,
 						Computed:            true,
 					},
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 				},
 				Optional: true,
 			},
@@ -67,8 +63,7 @@ func (d *RampConnectionDataSource) Schema(ctx context.Context, req datasource.Sc
 }
 
 type RampDataSourceConf struct {
-	Is_sandbox         bool   `mapstructure:"is_sandbox" tfsdk:"is_sandbox"`
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
+	Is_sandbox bool `mapstructure:"is_sandbox" tfsdk:"is_sandbox"`
 }
 
 func (d *RampConnectionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -106,8 +101,7 @@ func (d *RampConnectionDataSource) Read(ctx context.Context, req datasource.Read
 
 	var diags diag.Diagnostics
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"is_sandbox":         types.BoolType,
-		"oauth_token_expiry": types.StringType,
+		"is_sandbox": types.BoolType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/datasource_redditads_connection.go
+++ b/provider/internal/connections/datasource_redditads_connection.go
@@ -71,10 +71,6 @@ func (d *RedditadsConnectionDataSource) Schema(ctx context.Context, req datasour
 						MarkdownDescription: `Connected user's email`,
 						Computed:            true,
 					},
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 					"pixel_id": schema.StringAttribute{
 						MarkdownDescription: `Conversion Pixel ID
 
@@ -93,9 +89,8 @@ type RedditadsDataSourceConf struct {
 		Label string `mapstructure:"label" tfsdk:"label"`
 		Value string `mapstructure:"value" tfsdk:"value"`
 	} `mapstructure:"accounts" tfsdk:"accounts"`
-	Connected_user     string `mapstructure:"connected_user" tfsdk:"connected_user"`
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
-	Pixel_id           string `mapstructure:"pixel_id" tfsdk:"pixel_id"`
+	Connected_user string `mapstructure:"connected_user" tfsdk:"connected_user"`
+	Pixel_id       string `mapstructure:"pixel_id" tfsdk:"pixel_id"`
 }
 
 func (d *RedditadsConnectionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -141,9 +136,8 @@ func (d *RedditadsConnectionDataSource) Read(ctx context.Context, req datasource
 				},
 			},
 		},
-		"connected_user":     types.StringType,
-		"oauth_token_expiry": types.StringType,
-		"pixel_id":           types.StringType,
+		"connected_user": types.StringType,
+		"pixel_id":       types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/datasource_sageintacct_connection.go
+++ b/provider/internal/connections/datasource_sageintacct_connection.go
@@ -6,12 +6,9 @@ package connections
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/mitchellh/mapstructure"
 	"github.com/polytomic/terraform-provider-polytomic/internal/providerclient"
 )
 
@@ -50,20 +47,14 @@ func (d *SageintacctConnectionDataSource) Schema(ctx context.Context, req dataso
 				Computed:            true,
 			},
 			"configuration": schema.SingleNestedAttribute{
-				Attributes: map[string]schema.Attribute{
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
-				},
-				Optional: true,
+				Attributes: map[string]schema.Attribute{},
+				Optional:   true,
 			},
 		},
 	}
 }
 
 type SageintacctDataSourceConf struct {
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 }
 
 func (d *SageintacctConnectionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -91,22 +82,6 @@ func (d *SageintacctConnectionDataSource) Read(ctx context.Context, req datasour
 	data.Id = types.StringPointerValue(connection.Data.Id)
 	data.Name = types.StringPointerValue(connection.Data.Name)
 	data.Organization = types.StringPointerValue(connection.Data.OrganizationId)
-
-	conf := SageintacctDataSourceConf{}
-	err = mapstructure.Decode(connection.Data.Configuration, &conf)
-	if err != nil {
-		resp.Diagnostics.AddError("Error decoding connection configuration", err.Error())
-		return
-	}
-
-	var diags diag.Diagnostics
-	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"oauth_token_expiry": types.StringType,
-	}, conf)
-	if diags.HasError() {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/provider/internal/connections/datasource_salesloft_connection.go
+++ b/provider/internal/connections/datasource_salesloft_connection.go
@@ -59,10 +59,6 @@ func (d *SalesloftConnectionDataSource) Schema(ctx context.Context, req datasour
 						MarkdownDescription: `Connected user's email`,
 						Computed:            true,
 					},
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 				},
 				Optional: true,
 			},
@@ -71,9 +67,8 @@ func (d *SalesloftConnectionDataSource) Schema(ctx context.Context, req datasour
 }
 
 type SalesloftDataSourceConf struct {
-	Auth_method        string `mapstructure:"auth_method" tfsdk:"auth_method"`
-	Connected_user     string `mapstructure:"connected_user" tfsdk:"connected_user"`
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
+	Auth_method    string `mapstructure:"auth_method" tfsdk:"auth_method"`
+	Connected_user string `mapstructure:"connected_user" tfsdk:"connected_user"`
 }
 
 func (d *SalesloftConnectionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -111,9 +106,8 @@ func (d *SalesloftConnectionDataSource) Read(ctx context.Context, req datasource
 
 	var diags diag.Diagnostics
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"auth_method":        types.StringType,
-		"connected_user":     types.StringType,
-		"oauth_token_expiry": types.StringType,
+		"auth_method":    types.StringType,
+		"connected_user": types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/datasource_typeform_connection.go
+++ b/provider/internal/connections/datasource_typeform_connection.go
@@ -6,12 +6,9 @@ package connections
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/mitchellh/mapstructure"
 	"github.com/polytomic/terraform-provider-polytomic/internal/providerclient"
 )
 
@@ -50,20 +47,14 @@ func (d *TypeformConnectionDataSource) Schema(ctx context.Context, req datasourc
 				Computed:            true,
 			},
 			"configuration": schema.SingleNestedAttribute{
-				Attributes: map[string]schema.Attribute{
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
-				},
-				Optional: true,
+				Attributes: map[string]schema.Attribute{},
+				Optional:   true,
 			},
 		},
 	}
 }
 
 type TypeformDataSourceConf struct {
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 }
 
 func (d *TypeformConnectionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -91,22 +82,6 @@ func (d *TypeformConnectionDataSource) Read(ctx context.Context, req datasource.
 	data.Id = types.StringPointerValue(connection.Data.Id)
 	data.Name = types.StringPointerValue(connection.Data.Name)
 	data.Organization = types.StringPointerValue(connection.Data.OrganizationId)
-
-	conf := TypeformDataSourceConf{}
-	err = mapstructure.Decode(connection.Data.Configuration, &conf)
-	if err != nil {
-		resp.Diagnostics.AddError("Error decoding connection configuration", err.Error())
-		return
-	}
-
-	var diags diag.Diagnostics
-	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"oauth_token_expiry": types.StringType,
-	}, conf)
-	if diags.HasError() {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/provider/internal/connections/datasource_upfluence_connection.go
+++ b/provider/internal/connections/datasource_upfluence_connection.go
@@ -51,10 +51,6 @@ func (d *UpfluenceConnectionDataSource) Schema(ctx context.Context, req datasour
 			},
 			"configuration": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 					"username": schema.StringAttribute{
 						MarkdownDescription: `Email`,
 						Computed:            true,
@@ -67,8 +63,7 @@ func (d *UpfluenceConnectionDataSource) Schema(ctx context.Context, req datasour
 }
 
 type UpfluenceDataSourceConf struct {
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
-	Username           string `mapstructure:"username" tfsdk:"username"`
+	Username string `mapstructure:"username" tfsdk:"username"`
 }
 
 func (d *UpfluenceConnectionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -106,8 +101,7 @@ func (d *UpfluenceConnectionDataSource) Read(ctx context.Context, req datasource
 
 	var diags diag.Diagnostics
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"oauth_token_expiry": types.StringType,
-		"username":           types.StringType,
+		"username": types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/datasource_youtubeanalytics_connection.go
+++ b/provider/internal/connections/datasource_youtubeanalytics_connection.go
@@ -57,10 +57,6 @@ func (d *YoutubeanalyticsConnectionDataSource) Schema(ctx context.Context, req d
     If you are using a content owner account enter the content owner ID here. This is required for some reports.`,
 						Computed: true,
 					},
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 					"user_email": schema.StringAttribute{
 						MarkdownDescription: `Connected user's email`,
 						Computed:            true,
@@ -73,9 +69,8 @@ func (d *YoutubeanalyticsConnectionDataSource) Schema(ctx context.Context, req d
 }
 
 type YoutubeanalyticsDataSourceConf struct {
-	Content_owner_id   string `mapstructure:"content_owner_id" tfsdk:"content_owner_id"`
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
-	User_email         string `mapstructure:"user_email" tfsdk:"user_email"`
+	Content_owner_id string `mapstructure:"content_owner_id" tfsdk:"content_owner_id"`
+	User_email       string `mapstructure:"user_email" tfsdk:"user_email"`
 }
 
 func (d *YoutubeanalyticsConnectionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -113,9 +108,8 @@ func (d *YoutubeanalyticsConnectionDataSource) Read(ctx context.Context, req dat
 
 	var diags diag.Diagnostics
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"content_owner_id":   types.StringType,
-		"oauth_token_expiry": types.StringType,
-		"user_email":         types.StringType,
+		"content_owner_id": types.StringType,
+		"user_email":       types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/datasource_zendesk_support_connection.go
+++ b/provider/internal/connections/datasource_zendesk_support_connection.go
@@ -67,10 +67,6 @@ func (d *Zendesk_supportConnectionDataSource) Schema(ctx context.Context, req da
 						MarkdownDescription: ``,
 						Computed:            true,
 					},
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 					"ratelimit_rpm": schema.Int64Attribute{
 						MarkdownDescription: `Maximum requests per minute
 
@@ -85,12 +81,11 @@ func (d *Zendesk_supportConnectionDataSource) Schema(ctx context.Context, req da
 }
 
 type Zendesk_supportDataSourceConf struct {
-	Auth_method        string `mapstructure:"auth_method" tfsdk:"auth_method"`
-	Custom_api_limits  bool   `mapstructure:"custom_api_limits" tfsdk:"custom_api_limits"`
-	Domain             string `mapstructure:"domain" tfsdk:"domain"`
-	Email              string `mapstructure:"email" tfsdk:"email"`
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
-	Ratelimit_rpm      int64  `mapstructure:"ratelimit_rpm" tfsdk:"ratelimit_rpm"`
+	Auth_method       string `mapstructure:"auth_method" tfsdk:"auth_method"`
+	Custom_api_limits bool   `mapstructure:"custom_api_limits" tfsdk:"custom_api_limits"`
+	Domain            string `mapstructure:"domain" tfsdk:"domain"`
+	Email             string `mapstructure:"email" tfsdk:"email"`
+	Ratelimit_rpm     int64  `mapstructure:"ratelimit_rpm" tfsdk:"ratelimit_rpm"`
 }
 
 func (d *Zendesk_supportConnectionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -128,12 +123,11 @@ func (d *Zendesk_supportConnectionDataSource) Read(ctx context.Context, req data
 
 	var diags diag.Diagnostics
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"auth_method":        types.StringType,
-		"custom_api_limits":  types.BoolType,
-		"domain":             types.StringType,
-		"email":              types.StringType,
-		"oauth_token_expiry": types.StringType,
-		"ratelimit_rpm":      types.NumberType,
+		"auth_method":       types.StringType,
+		"custom_api_limits": types.BoolType,
+		"domain":            types.StringType,
+		"email":             types.StringType,
+		"ratelimit_rpm":     types.NumberType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/datasource_zoho_crm_connection.go
+++ b/provider/internal/connections/datasource_zoho_crm_connection.go
@@ -51,10 +51,6 @@ func (d *Zoho_crmConnectionDataSource) Schema(ctx context.Context, req datasourc
 			},
 			"configuration": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
-					"oauth_token_expiry": schema.StringAttribute{
-						MarkdownDescription: ``,
-						Computed:            true,
-					},
 					"region": schema.StringAttribute{
 						MarkdownDescription: `Data center region Valid values: <code>usa</code> (USA), <code>europe</code> (Europe), <code>australia</code> (Australia), <code>canada</code> (Canada), <code>china</code> (China), <code>japan</code> (Japan), <code>saudi_arabia</code> (Saudi Arabia). Default: <code>usa</code>.`,
 						Computed:            true,
@@ -67,8 +63,7 @@ func (d *Zoho_crmConnectionDataSource) Schema(ctx context.Context, req datasourc
 }
 
 type Zoho_crmDataSourceConf struct {
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
-	Region             string `mapstructure:"region" tfsdk:"region"`
+	Region string `mapstructure:"region" tfsdk:"region"`
 }
 
 func (d *Zoho_crmConnectionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -106,8 +101,7 @@ func (d *Zoho_crmConnectionDataSource) Read(ctx context.Context, req datasource.
 
 	var diags diag.Diagnostics
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"oauth_token_expiry": types.StringType,
-		"region":             types.StringType,
+		"region": types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/resource_dbtprojectrepository_connection.go
+++ b/provider/internal/connections/resource_dbtprojectrepository_connection.go
@@ -107,13 +107,6 @@ var DbtprojectrepositorySchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 				"repository": schema.StringAttribute{
 					MarkdownDescription: `dbt project repository
 
@@ -159,7 +152,6 @@ type DbtprojectrepositoryConf struct {
 	} `mapstructure:"latest_commit" tfsdk:"latest_commit"`
 	Oauth_access_token  string `mapstructure:"oauth_access_token" tfsdk:"oauth_access_token"`
 	Oauth_refresh_token string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry  string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 	Repository          string `mapstructure:"repository" tfsdk:"repository"`
 }
 
@@ -247,7 +239,6 @@ func (r *DbtprojectrepositoryConnectionResource) Create(ctx context.Context, req
 			},
 		}, "oauth_access_token": types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"repository":          types.StringType,
 	}, conf)
 	if diags.HasError() {
@@ -329,7 +320,6 @@ func (r *DbtprojectrepositoryConnectionResource) Read(ctx context.Context, req r
 			},
 		}, "oauth_access_token": types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"repository":          types.StringType,
 	}, conf)
 	if diags.HasError() {
@@ -421,7 +411,6 @@ func (r *DbtprojectrepositoryConnectionResource) Update(ctx context.Context, req
 			},
 		}, "oauth_access_token": types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"repository":          types.StringType,
 	}, conf)
 	if diags.HasError() {

--- a/provider/internal/connections/resource_dialpad_connection.go
+++ b/provider/internal/connections/resource_dialpad_connection.go
@@ -96,13 +96,6 @@ var DialpadSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 			},
 
 			Required: true,
@@ -135,7 +128,6 @@ type DialpadConf struct {
 	Auth_method         string `mapstructure:"auth_method" tfsdk:"auth_method"`
 	Client_secret       string `mapstructure:"client_secret" tfsdk:"client_secret"`
 	Oauth_refresh_token string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry  string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 }
 
 type DialpadConnectionResource struct {
@@ -217,7 +209,6 @@ func (r *DialpadConnectionResource) Create(ctx context.Context, req resource.Cre
 		"auth_method":         types.StringType,
 		"client_secret":       types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -293,7 +284,6 @@ func (r *DialpadConnectionResource) Read(ctx context.Context, req resource.ReadR
 		"auth_method":         types.StringType,
 		"client_secret":       types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -379,7 +369,6 @@ func (r *DialpadConnectionResource) Update(ctx context.Context, req resource.Upd
 		"auth_method":         types.StringType,
 		"client_secret":       types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/resource_dropbox_connection.go
+++ b/provider/internal/connections/resource_dropbox_connection.go
@@ -115,13 +115,6 @@ var DropboxSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 				"single_table_file_format": schema.StringAttribute{
 					MarkdownDescription: `File format Valid values: <code>csv</code> (CSV), <code>json</code> (JSON), <code>parquet</code> (Parquet). Default: <code>csv</code>.`,
 					Required:            false,
@@ -194,7 +187,6 @@ type DropboxConf struct {
 	Is_directory_snapshot     bool     `mapstructure:"is_directory_snapshot" tfsdk:"is_directory_snapshot"`
 	Is_single_table           bool     `mapstructure:"is_single_table" tfsdk:"is_single_table"`
 	Oauth_refresh_token       string   `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry        string   `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 	Single_table_file_format  string   `mapstructure:"single_table_file_format" tfsdk:"single_table_file_format"`
 	Single_table_file_formats []string `mapstructure:"single_table_file_formats" tfsdk:"single_table_file_formats"`
 	Single_table_name         string   `mapstructure:"single_table_name" tfsdk:"single_table_name"`
@@ -283,7 +275,6 @@ func (r *DropboxConnectionResource) Create(ctx context.Context, req resource.Cre
 		"is_directory_snapshot":    types.BoolType,
 		"is_single_table":          types.BoolType,
 		"oauth_refresh_token":      types.StringType,
-		"oauth_token_expiry":       types.StringType,
 		"single_table_file_format": types.StringType,
 		"single_table_file_formats": types.SetType{
 			ElemType: types.StringType,
@@ -368,7 +359,6 @@ func (r *DropboxConnectionResource) Read(ctx context.Context, req resource.ReadR
 		"is_directory_snapshot":    types.BoolType,
 		"is_single_table":          types.BoolType,
 		"oauth_refresh_token":      types.StringType,
-		"oauth_token_expiry":       types.StringType,
 		"single_table_file_format": types.StringType,
 		"single_table_file_formats": types.SetType{
 			ElemType: types.StringType,
@@ -463,7 +453,6 @@ func (r *DropboxConnectionResource) Update(ctx context.Context, req resource.Upd
 		"is_directory_snapshot":    types.BoolType,
 		"is_single_table":          types.BoolType,
 		"oauth_refresh_token":      types.StringType,
-		"oauth_token_expiry":       types.StringType,
 		"single_table_file_format": types.StringType,
 		"single_table_file_formats": types.SetType{
 			ElemType: types.StringType,

--- a/provider/internal/connections/resource_github_connection.go
+++ b/provider/internal/connections/resource_github_connection.go
@@ -43,13 +43,6 @@ var GithubSchema = schema.Schema{
 		},
 		"configuration": schema.SingleNestedAttribute{
 			Attributes: map[string]schema.Attribute{
-				"authenticated": schema.BoolAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 				"client_id": schema.StringAttribute{
 					MarkdownDescription: ``,
 					Required:            false,
@@ -132,7 +125,6 @@ func (t *GithubConnectionResource) Schema(ctx context.Context, req resource.Sche
 }
 
 type GithubConf struct {
-	Authenticated      bool   `mapstructure:"authenticated" tfsdk:"authenticated"`
 	Client_id          string `mapstructure:"client_id" tfsdk:"client_id"`
 	Client_secret      string `mapstructure:"client_secret" tfsdk:"client_secret"`
 	Oauth_access_token string `mapstructure:"oauth_access_token" tfsdk:"oauth_access_token"`
@@ -216,7 +208,6 @@ func (r *GithubConnectionResource) Create(ctx context.Context, req resource.Crea
 	}
 
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"authenticated":      types.BoolType,
 		"client_id":          types.StringType,
 		"client_secret":      types.StringType,
 		"oauth_access_token": types.StringType,
@@ -298,7 +289,6 @@ func (r *GithubConnectionResource) Read(ctx context.Context, req resource.ReadRe
 	}
 
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"authenticated":      types.BoolType,
 		"client_id":          types.StringType,
 		"client_secret":      types.StringType,
 		"oauth_access_token": types.StringType,
@@ -390,7 +380,6 @@ func (r *GithubConnectionResource) Update(ctx context.Context, req resource.Upda
 	}
 
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"authenticated":      types.BoolType,
 		"client_id":          types.StringType,
 		"client_secret":      types.StringType,
 		"oauth_access_token": types.StringType,

--- a/provider/internal/connections/resource_gmail_connection.go
+++ b/provider/internal/connections/resource_gmail_connection.go
@@ -73,13 +73,6 @@ var GmailSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 				"user_email": schema.StringAttribute{
 					MarkdownDescription: `Connected user's email`,
 					Required:            false,
@@ -117,7 +110,6 @@ type GmailConf struct {
 	Client_id           string `mapstructure:"client_id" tfsdk:"client_id"`
 	Client_secret       string `mapstructure:"client_secret" tfsdk:"client_secret"`
 	Oauth_refresh_token string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry  string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 	User_email          string `mapstructure:"user_email" tfsdk:"user_email"`
 }
 
@@ -198,7 +190,6 @@ func (r *GmailConnectionResource) Create(ctx context.Context, req resource.Creat
 		"client_id":           types.StringType,
 		"client_secret":       types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"user_email":          types.StringType,
 	}, conf)
 	if diags.HasError() {
@@ -273,7 +264,6 @@ func (r *GmailConnectionResource) Read(ctx context.Context, req resource.ReadReq
 		"client_id":           types.StringType,
 		"client_secret":       types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"user_email":          types.StringType,
 	}, conf)
 	if diags.HasError() {
@@ -358,7 +348,6 @@ func (r *GmailConnectionResource) Update(ctx context.Context, req resource.Updat
 		"client_id":           types.StringType,
 		"client_secret":       types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"user_email":          types.StringType,
 	}, conf)
 	if diags.HasError() {

--- a/provider/internal/connections/resource_gong_connection.go
+++ b/provider/internal/connections/resource_gong_connection.go
@@ -103,13 +103,6 @@ var GongSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 				"subdomain": schema.StringAttribute{
 					MarkdownDescription: `Gong subdomain i.e. company-17 if you access Gong via https://company-17.app.gong.io`,
 					Required:            false,
@@ -150,7 +143,6 @@ type GongConf struct {
 	Client_id           string `mapstructure:"client_id" tfsdk:"client_id"`
 	Client_secret       string `mapstructure:"client_secret" tfsdk:"client_secret"`
 	Oauth_refresh_token string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry  string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 	Subdomain           string `mapstructure:"subdomain" tfsdk:"subdomain"`
 }
 
@@ -234,7 +226,6 @@ func (r *GongConnectionResource) Create(ctx context.Context, req resource.Create
 		"client_id":           types.StringType,
 		"client_secret":       types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"subdomain":           types.StringType,
 	}, conf)
 	if diags.HasError() {
@@ -312,7 +303,6 @@ func (r *GongConnectionResource) Read(ctx context.Context, req resource.ReadRequ
 		"client_id":           types.StringType,
 		"client_secret":       types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"subdomain":           types.StringType,
 	}, conf)
 	if diags.HasError() {
@@ -400,7 +390,6 @@ func (r *GongConnectionResource) Update(ctx context.Context, req resource.Update
 		"client_id":           types.StringType,
 		"client_secret":       types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"subdomain":           types.StringType,
 	}, conf)
 	if diags.HasError() {

--- a/provider/internal/connections/resource_googleads_connection.go
+++ b/provider/internal/connections/resource_googleads_connection.go
@@ -123,13 +123,6 @@ var GoogleadsSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 			},
 
 			Required: true,
@@ -167,7 +160,6 @@ type GoogleadsConf struct {
 	Connected_user       string `mapstructure:"connected_user" tfsdk:"connected_user"`
 	Custom_reports       string `mapstructure:"custom_reports" tfsdk:"custom_reports"`
 	Oauth_refresh_token  string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry   string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 }
 
 type GoogleadsConnectionResource struct {
@@ -258,7 +250,6 @@ func (r *GoogleadsConnectionResource) Create(ctx context.Context, req resource.C
 		"connected_user":       types.StringType,
 		"custom_reports":       types.StringType,
 		"oauth_refresh_token":  types.StringType,
-		"oauth_token_expiry":   types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -343,7 +334,6 @@ func (r *GoogleadsConnectionResource) Read(ctx context.Context, req resource.Rea
 		"connected_user":       types.StringType,
 		"custom_reports":       types.StringType,
 		"oauth_refresh_token":  types.StringType,
-		"oauth_token_expiry":   types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -438,7 +428,6 @@ func (r *GoogleadsConnectionResource) Update(ctx context.Context, req resource.U
 		"connected_user":       types.StringType,
 		"custom_reports":       types.StringType,
 		"oauth_refresh_token":  types.StringType,
-		"oauth_token_expiry":   types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/resource_googleanalytics_connection.go
+++ b/provider/internal/connections/resource_googleanalytics_connection.go
@@ -95,13 +95,6 @@ var GoogleanalyticsSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 				"properties": schema.SetNestedAttribute{
 					MarkdownDescription: ``,
 					Required:            false,
@@ -176,7 +169,6 @@ type GoogleanalyticsConf struct {
 	Client_secret       string `mapstructure:"client_secret" tfsdk:"client_secret"`
 	Custom_reports      string `mapstructure:"custom_reports" tfsdk:"custom_reports"`
 	Oauth_refresh_token string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry  string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 	Properties          []struct {
 		Label string `mapstructure:"label" tfsdk:"label"`
 		Value string `mapstructure:"value" tfsdk:"value"`
@@ -264,7 +256,6 @@ func (r *GoogleanalyticsConnectionResource) Create(ctx context.Context, req reso
 		"client_secret":       types.StringType,
 		"custom_reports":      types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"properties": types.SetType{
 			ElemType: types.ObjectType{
 				AttrTypes: map[string]attr.Type{
@@ -350,7 +341,6 @@ func (r *GoogleanalyticsConnectionResource) Read(ctx context.Context, req resour
 		"client_secret":       types.StringType,
 		"custom_reports":      types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"properties": types.SetType{
 			ElemType: types.ObjectType{
 				AttrTypes: map[string]attr.Type{
@@ -446,7 +436,6 @@ func (r *GoogleanalyticsConnectionResource) Update(ctx context.Context, req reso
 		"client_secret":       types.StringType,
 		"custom_reports":      types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"properties": types.SetType{
 			ElemType: types.ObjectType{
 				AttrTypes: map[string]attr.Type{

--- a/provider/internal/connections/resource_googlesearchconsole_connection.go
+++ b/provider/internal/connections/resource_googlesearchconsole_connection.go
@@ -73,13 +73,6 @@ var GooglesearchconsoleSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 				"sites": schema.SetNestedAttribute{
 					MarkdownDescription: ``,
 					Required:            false,
@@ -135,7 +128,6 @@ type GooglesearchconsoleConf struct {
 	Client_id           string `mapstructure:"client_id" tfsdk:"client_id"`
 	Client_secret       string `mapstructure:"client_secret" tfsdk:"client_secret"`
 	Oauth_refresh_token string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry  string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 	Sites               []struct {
 		Label string `mapstructure:"label" tfsdk:"label"`
 		Value string `mapstructure:"value" tfsdk:"value"`
@@ -219,7 +211,6 @@ func (r *GooglesearchconsoleConnectionResource) Create(ctx context.Context, req 
 		"client_id":           types.StringType,
 		"client_secret":       types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"sites": types.SetType{
 			ElemType: types.ObjectType{
 				AttrTypes: map[string]attr.Type{
@@ -301,7 +292,6 @@ func (r *GooglesearchconsoleConnectionResource) Read(ctx context.Context, req re
 		"client_id":           types.StringType,
 		"client_secret":       types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"sites": types.SetType{
 			ElemType: types.ObjectType{
 				AttrTypes: map[string]attr.Type{
@@ -393,7 +383,6 @@ func (r *GooglesearchconsoleConnectionResource) Update(ctx context.Context, req 
 		"client_id":           types.StringType,
 		"client_secret":       types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"sites": types.SetType{
 			ElemType: types.ObjectType{
 				AttrTypes: map[string]attr.Type{

--- a/provider/internal/connections/resource_googleslides_connection.go
+++ b/provider/internal/connections/resource_googleslides_connection.go
@@ -116,13 +116,6 @@ var GoogleslidesSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 				"service_account": schema.StringAttribute{
 					MarkdownDescription: `Service account key`,
 					Required:            false,
@@ -176,7 +169,6 @@ type GoogleslidesConf struct {
 	} `mapstructure:"folder_id" tfsdk:"folder_id"`
 	Include_subdirectories bool   `mapstructure:"include_subdirectories" tfsdk:"include_subdirectories"`
 	Oauth_refresh_token    string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry     string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 	Service_account        string `mapstructure:"service_account" tfsdk:"service_account"`
 	User_email             string `mapstructure:"user_email" tfsdk:"user_email"`
 }
@@ -265,7 +257,6 @@ func (r *GoogleslidesConnectionResource) Create(ctx context.Context, req resourc
 			},
 		}, "include_subdirectories": types.BoolType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"service_account":     types.StringType,
 		"user_email":          types.StringType,
 	}, conf)
@@ -348,7 +339,6 @@ func (r *GoogleslidesConnectionResource) Read(ctx context.Context, req resource.
 			},
 		}, "include_subdirectories": types.BoolType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"service_account":     types.StringType,
 		"user_email":          types.StringType,
 	}, conf)
@@ -441,7 +431,6 @@ func (r *GoogleslidesConnectionResource) Update(ctx context.Context, req resourc
 			},
 		}, "include_subdirectories": types.BoolType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"service_account":     types.StringType,
 		"user_email":          types.StringType,
 	}, conf)

--- a/provider/internal/connections/resource_googleworkspace_connection.go
+++ b/provider/internal/connections/resource_googleworkspace_connection.go
@@ -90,13 +90,6 @@ var GoogleworkspaceSchema = schema.Schema{
 					Computed:            true,
 					Sensitive:           false,
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 				"service_account": schema.StringAttribute{
 					MarkdownDescription: `Service account key`,
 					Required:            false,
@@ -134,13 +127,12 @@ func (t *GoogleworkspaceConnectionResource) Schema(ctx context.Context, req reso
 }
 
 type GoogleworkspaceConf struct {
-	Auth_method        string `mapstructure:"auth_method" tfsdk:"auth_method"`
-	Client_email       string `mapstructure:"client_email" tfsdk:"client_email"`
-	Client_id          string `mapstructure:"client_id" tfsdk:"client_id"`
-	Client_secret      string `mapstructure:"client_secret" tfsdk:"client_secret"`
-	Customer_id        string `mapstructure:"customer_id" tfsdk:"customer_id"`
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
-	Service_account    string `mapstructure:"service_account" tfsdk:"service_account"`
+	Auth_method     string `mapstructure:"auth_method" tfsdk:"auth_method"`
+	Client_email    string `mapstructure:"client_email" tfsdk:"client_email"`
+	Client_id       string `mapstructure:"client_id" tfsdk:"client_id"`
+	Client_secret   string `mapstructure:"client_secret" tfsdk:"client_secret"`
+	Customer_id     string `mapstructure:"customer_id" tfsdk:"customer_id"`
+	Service_account string `mapstructure:"service_account" tfsdk:"service_account"`
 }
 
 type GoogleworkspaceConnectionResource struct {
@@ -217,13 +209,12 @@ func (r *GoogleworkspaceConnectionResource) Create(ctx context.Context, req reso
 	}
 
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"auth_method":        types.StringType,
-		"client_email":       types.StringType,
-		"client_id":          types.StringType,
-		"client_secret":      types.StringType,
-		"customer_id":        types.StringType,
-		"oauth_token_expiry": types.StringType,
-		"service_account":    types.StringType,
+		"auth_method":     types.StringType,
+		"client_email":    types.StringType,
+		"client_id":       types.StringType,
+		"client_secret":   types.StringType,
+		"customer_id":     types.StringType,
+		"service_account": types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -294,13 +285,12 @@ func (r *GoogleworkspaceConnectionResource) Read(ctx context.Context, req resour
 	}
 
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"auth_method":        types.StringType,
-		"client_email":       types.StringType,
-		"client_id":          types.StringType,
-		"client_secret":      types.StringType,
-		"customer_id":        types.StringType,
-		"oauth_token_expiry": types.StringType,
-		"service_account":    types.StringType,
+		"auth_method":     types.StringType,
+		"client_email":    types.StringType,
+		"client_id":       types.StringType,
+		"client_secret":   types.StringType,
+		"customer_id":     types.StringType,
+		"service_account": types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -381,13 +371,12 @@ func (r *GoogleworkspaceConnectionResource) Update(ctx context.Context, req reso
 	}
 
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"auth_method":        types.StringType,
-		"client_email":       types.StringType,
-		"client_id":          types.StringType,
-		"client_secret":      types.StringType,
-		"customer_id":        types.StringType,
-		"oauth_token_expiry": types.StringType,
-		"service_account":    types.StringType,
+		"auth_method":     types.StringType,
+		"client_email":    types.StringType,
+		"client_id":       types.StringType,
+		"client_secret":   types.StringType,
+		"customer_id":     types.StringType,
+		"service_account": types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/resource_gsheets_connection.go
+++ b/provider/internal/connections/resource_gsheets_connection.go
@@ -93,13 +93,6 @@ var GsheetsSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 				"service_account": schema.StringAttribute{
 					MarkdownDescription: `Service account key`,
 					Required:            false,
@@ -172,7 +165,6 @@ type GsheetsConf struct {
 	Connect_mode        string `mapstructure:"connect_mode" tfsdk:"connect_mode"`
 	Has_headers         bool   `mapstructure:"has_headers" tfsdk:"has_headers"`
 	Oauth_refresh_token string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry  string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 	Service_account     string `mapstructure:"service_account" tfsdk:"service_account"`
 	Spreadsheet_id      struct {
 		Label string `mapstructure:"label" tfsdk:"label"`
@@ -260,7 +252,6 @@ func (r *GsheetsConnectionResource) Create(ctx context.Context, req resource.Cre
 		"connect_mode":        types.StringType,
 		"has_headers":         types.BoolType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"service_account":     types.StringType,
 		"spreadsheet_id": types.ObjectType{
 			AttrTypes: map[string]attr.Type{
@@ -343,7 +334,6 @@ func (r *GsheetsConnectionResource) Read(ctx context.Context, req resource.ReadR
 		"connect_mode":        types.StringType,
 		"has_headers":         types.BoolType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"service_account":     types.StringType,
 		"spreadsheet_id": types.ObjectType{
 			AttrTypes: map[string]attr.Type{
@@ -436,7 +426,6 @@ func (r *GsheetsConnectionResource) Update(ctx context.Context, req resource.Upd
 		"connect_mode":        types.StringType,
 		"has_headers":         types.BoolType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"service_account":     types.StringType,
 		"spreadsheet_id": types.ObjectType{
 			AttrTypes: map[string]attr.Type{

--- a/provider/internal/connections/resource_linkedinads_connection.go
+++ b/provider/internal/connections/resource_linkedinads_connection.go
@@ -105,13 +105,6 @@ var LinkedinadsSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 			},
 
 			Required: true,
@@ -147,7 +140,6 @@ type LinkedinadsConf struct {
 	Client_secret       string `mapstructure:"client_secret" tfsdk:"client_secret"`
 	Connected_user      string `mapstructure:"connected_user" tfsdk:"connected_user"`
 	Oauth_refresh_token string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry  string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 }
 
 type LinkedinadsConnectionResource struct {
@@ -236,7 +228,6 @@ func (r *LinkedinadsConnectionResource) Create(ctx context.Context, req resource
 		"client_secret":       types.StringType,
 		"connected_user":      types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -319,7 +310,6 @@ func (r *LinkedinadsConnectionResource) Read(ctx context.Context, req resource.R
 		"client_secret":       types.StringType,
 		"connected_user":      types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -412,7 +402,6 @@ func (r *LinkedinadsConnectionResource) Update(ctx context.Context, req resource
 		"client_secret":       types.StringType,
 		"connected_user":      types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/resource_marketo_connection.go
+++ b/provider/internal/connections/resource_marketo_connection.go
@@ -88,13 +88,6 @@ var MarketoSchema = schema.Schema{
 					Computed:            true,
 					Sensitive:           false,
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 				"rest_endpoint": schema.StringAttribute{
 					MarkdownDescription: `REST Endpoint`,
 					Required:            true,
@@ -135,7 +128,6 @@ type MarketoConf struct {
 	Daily_api_calls      int64  `mapstructure:"daily_api_calls" tfsdk:"daily_api_calls"`
 	Enforce_api_limits   bool   `mapstructure:"enforce_api_limits" tfsdk:"enforce_api_limits"`
 	Include_static_lists bool   `mapstructure:"include_static_lists" tfsdk:"include_static_lists"`
-	Oauth_token_expiry   string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 	Rest_endpoint        string `mapstructure:"rest_endpoint" tfsdk:"rest_endpoint"`
 }
 
@@ -219,7 +211,6 @@ func (r *MarketoConnectionResource) Create(ctx context.Context, req resource.Cre
 		"daily_api_calls":      types.NumberType,
 		"enforce_api_limits":   types.BoolType,
 		"include_static_lists": types.BoolType,
-		"oauth_token_expiry":   types.StringType,
 		"rest_endpoint":        types.StringType,
 	}, conf)
 	if diags.HasError() {
@@ -297,7 +288,6 @@ func (r *MarketoConnectionResource) Read(ctx context.Context, req resource.ReadR
 		"daily_api_calls":      types.NumberType,
 		"enforce_api_limits":   types.BoolType,
 		"include_static_lists": types.BoolType,
-		"oauth_token_expiry":   types.StringType,
 		"rest_endpoint":        types.StringType,
 	}, conf)
 	if diags.HasError() {
@@ -385,7 +375,6 @@ func (r *MarketoConnectionResource) Update(ctx context.Context, req resource.Upd
 		"daily_api_calls":      types.NumberType,
 		"enforce_api_limits":   types.BoolType,
 		"include_static_lists": types.BoolType,
-		"oauth_token_expiry":   types.StringType,
 		"rest_endpoint":        types.StringType,
 	}, conf)
 	if diags.HasError() {

--- a/provider/internal/connections/resource_msads_connection.go
+++ b/provider/internal/connections/resource_msads_connection.go
@@ -118,13 +118,6 @@ var MsadsSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 				"username": schema.StringAttribute{
 					MarkdownDescription: `Connected user`,
 					Required:            false,
@@ -168,7 +161,6 @@ type MsadsConf struct {
 	Client_id                  string `mapstructure:"client_id" tfsdk:"client_id"`
 	Client_secret              string `mapstructure:"client_secret" tfsdk:"client_secret"`
 	Oauth_refresh_token        string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry         string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 	Username                   string `mapstructure:"username" tfsdk:"username"`
 }
 
@@ -259,7 +251,6 @@ func (r *MsadsConnectionResource) Create(ctx context.Context, req resource.Creat
 		"client_id":                  types.StringType,
 		"client_secret":              types.StringType,
 		"oauth_refresh_token":        types.StringType,
-		"oauth_token_expiry":         types.StringType,
 		"username":                   types.StringType,
 	}, conf)
 	if diags.HasError() {
@@ -344,7 +335,6 @@ func (r *MsadsConnectionResource) Read(ctx context.Context, req resource.ReadReq
 		"client_id":                  types.StringType,
 		"client_secret":              types.StringType,
 		"oauth_refresh_token":        types.StringType,
-		"oauth_token_expiry":         types.StringType,
 		"username":                   types.StringType,
 	}, conf)
 	if diags.HasError() {
@@ -439,7 +429,6 @@ func (r *MsadsConnectionResource) Update(ctx context.Context, req resource.Updat
 		"client_id":                  types.StringType,
 		"client_secret":              types.StringType,
 		"oauth_refresh_token":        types.StringType,
-		"oauth_token_expiry":         types.StringType,
 		"username":                   types.StringType,
 	}, conf)
 	if diags.HasError() {

--- a/provider/internal/connections/resource_msdynamics_connection.go
+++ b/provider/internal/connections/resource_msdynamics_connection.go
@@ -80,13 +80,6 @@ var MsdynamicsSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 			},
 
 			Required: true,
@@ -118,7 +111,6 @@ type MsdynamicsConf struct {
 	Client_secret       string `mapstructure:"client_secret" tfsdk:"client_secret"`
 	Dynamics_url        string `mapstructure:"dynamics_url" tfsdk:"dynamics_url"`
 	Oauth_refresh_token string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry  string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 }
 
 type MsdynamicsConnectionResource struct {
@@ -199,7 +191,6 @@ func (r *MsdynamicsConnectionResource) Create(ctx context.Context, req resource.
 		"client_secret":       types.StringType,
 		"dynamics_url":        types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -274,7 +265,6 @@ func (r *MsdynamicsConnectionResource) Read(ctx context.Context, req resource.Re
 		"client_secret":       types.StringType,
 		"dynamics_url":        types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -359,7 +349,6 @@ func (r *MsdynamicsConnectionResource) Update(ctx context.Context, req resource.
 		"client_secret":       types.StringType,
 		"dynamics_url":        types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/resource_outreach_connection.go
+++ b/provider/internal/connections/resource_outreach_connection.go
@@ -80,13 +80,6 @@ var OutreachSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 				"use_bulk_upsert": schema.BoolAttribute{
 					MarkdownDescription: `Use bulk API for syncing to Outreach Default: <code>true</code>.`,
 					Required:            false,
@@ -125,7 +118,6 @@ type OutreachConf struct {
 	Client_secret       string `mapstructure:"client_secret" tfsdk:"client_secret"`
 	Connected_user      string `mapstructure:"connected_user" tfsdk:"connected_user"`
 	Oauth_refresh_token string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry  string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 	Use_bulk_upsert     bool   `mapstructure:"use_bulk_upsert" tfsdk:"use_bulk_upsert"`
 }
 
@@ -207,7 +199,6 @@ func (r *OutreachConnectionResource) Create(ctx context.Context, req resource.Cr
 		"client_secret":       types.StringType,
 		"connected_user":      types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"use_bulk_upsert":     types.BoolType,
 	}, conf)
 	if diags.HasError() {
@@ -283,7 +274,6 @@ func (r *OutreachConnectionResource) Read(ctx context.Context, req resource.Read
 		"client_secret":       types.StringType,
 		"connected_user":      types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"use_bulk_upsert":     types.BoolType,
 	}, conf)
 	if diags.HasError() {
@@ -369,7 +359,6 @@ func (r *OutreachConnectionResource) Update(ctx context.Context, req resource.Up
 		"client_secret":       types.StringType,
 		"connected_user":      types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"use_bulk_upsert":     types.BoolType,
 	}, conf)
 	if diags.HasError() {

--- a/provider/internal/connections/resource_quickbooks_connection.go
+++ b/provider/internal/connections/resource_quickbooks_connection.go
@@ -73,13 +73,6 @@ var QuickbooksSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 				"realm_id": schema.StringAttribute{
 					MarkdownDescription: `Company ID`,
 					Required:            true,
@@ -117,7 +110,6 @@ type QuickbooksConf struct {
 	Client_id           string `mapstructure:"client_id" tfsdk:"client_id"`
 	Client_secret       string `mapstructure:"client_secret" tfsdk:"client_secret"`
 	Oauth_refresh_token string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry  string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 	Realm_id            string `mapstructure:"realm_id" tfsdk:"realm_id"`
 }
 
@@ -198,7 +190,6 @@ func (r *QuickbooksConnectionResource) Create(ctx context.Context, req resource.
 		"client_id":           types.StringType,
 		"client_secret":       types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"realm_id":            types.StringType,
 	}, conf)
 	if diags.HasError() {
@@ -273,7 +264,6 @@ func (r *QuickbooksConnectionResource) Read(ctx context.Context, req resource.Re
 		"client_id":           types.StringType,
 		"client_secret":       types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"realm_id":            types.StringType,
 	}, conf)
 	if diags.HasError() {
@@ -358,7 +348,6 @@ func (r *QuickbooksConnectionResource) Update(ctx context.Context, req resource.
 		"client_id":           types.StringType,
 		"client_secret":       types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"realm_id":            types.StringType,
 	}, conf)
 	if diags.HasError() {

--- a/provider/internal/connections/resource_ramp_connection.go
+++ b/provider/internal/connections/resource_ramp_connection.go
@@ -80,13 +80,6 @@ var RampSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 			},
 
 			Required: true,
@@ -118,7 +111,6 @@ type RampConf struct {
 	Client_secret       string `mapstructure:"client_secret" tfsdk:"client_secret"`
 	Is_sandbox          bool   `mapstructure:"is_sandbox" tfsdk:"is_sandbox"`
 	Oauth_refresh_token string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry  string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 }
 
 type RampConnectionResource struct {
@@ -199,7 +191,6 @@ func (r *RampConnectionResource) Create(ctx context.Context, req resource.Create
 		"client_secret":       types.StringType,
 		"is_sandbox":          types.BoolType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -274,7 +265,6 @@ func (r *RampConnectionResource) Read(ctx context.Context, req resource.ReadRequ
 		"client_secret":       types.StringType,
 		"is_sandbox":          types.BoolType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -359,7 +349,6 @@ func (r *RampConnectionResource) Update(ctx context.Context, req resource.Update
 		"client_secret":       types.StringType,
 		"is_sandbox":          types.BoolType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/resource_redditads_connection.go
+++ b/provider/internal/connections/resource_redditads_connection.go
@@ -105,13 +105,6 @@ var RedditadsSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 				"pixel_id": schema.StringAttribute{
 					MarkdownDescription: `Conversion Pixel ID
 
@@ -156,7 +149,6 @@ type RedditadsConf struct {
 	Client_secret       string `mapstructure:"client_secret" tfsdk:"client_secret"`
 	Connected_user      string `mapstructure:"connected_user" tfsdk:"connected_user"`
 	Oauth_refresh_token string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry  string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 	Pixel_id            string `mapstructure:"pixel_id" tfsdk:"pixel_id"`
 }
 
@@ -246,7 +238,6 @@ func (r *RedditadsConnectionResource) Create(ctx context.Context, req resource.C
 		"client_secret":       types.StringType,
 		"connected_user":      types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"pixel_id":            types.StringType,
 	}, conf)
 	if diags.HasError() {
@@ -330,7 +321,6 @@ func (r *RedditadsConnectionResource) Read(ctx context.Context, req resource.Rea
 		"client_secret":       types.StringType,
 		"connected_user":      types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"pixel_id":            types.StringType,
 	}, conf)
 	if diags.HasError() {
@@ -424,7 +414,6 @@ func (r *RedditadsConnectionResource) Update(ctx context.Context, req resource.U
 		"client_secret":       types.StringType,
 		"connected_user":      types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"pixel_id":            types.StringType,
 	}, conf)
 	if diags.HasError() {

--- a/provider/internal/connections/resource_sageintacct_connection.go
+++ b/provider/internal/connections/resource_sageintacct_connection.go
@@ -73,13 +73,6 @@ var SageintacctSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 			},
 
 			Required: true,
@@ -110,7 +103,6 @@ type SageintacctConf struct {
 	Application_id      string `mapstructure:"application_id" tfsdk:"application_id"`
 	Client_secret       string `mapstructure:"client_secret" tfsdk:"client_secret"`
 	Oauth_refresh_token string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry  string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 }
 
 type SageintacctConnectionResource struct {
@@ -190,7 +182,6 @@ func (r *SageintacctConnectionResource) Create(ctx context.Context, req resource
 		"application_id":      types.StringType,
 		"client_secret":       types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -264,7 +255,6 @@ func (r *SageintacctConnectionResource) Read(ctx context.Context, req resource.R
 		"application_id":      types.StringType,
 		"client_secret":       types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -348,7 +338,6 @@ func (r *SageintacctConnectionResource) Update(ctx context.Context, req resource
 		"application_id":      types.StringType,
 		"client_secret":       types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/resource_salesloft_connection.go
+++ b/provider/internal/connections/resource_salesloft_connection.go
@@ -103,13 +103,6 @@ var SalesloftSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 			},
 
 			Required: true,
@@ -143,7 +136,6 @@ type SalesloftConf struct {
 	Client_secret       string `mapstructure:"client_secret" tfsdk:"client_secret"`
 	Connected_user      string `mapstructure:"connected_user" tfsdk:"connected_user"`
 	Oauth_refresh_token string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry  string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 }
 
 type SalesloftConnectionResource struct {
@@ -226,7 +218,6 @@ func (r *SalesloftConnectionResource) Create(ctx context.Context, req resource.C
 		"client_secret":       types.StringType,
 		"connected_user":      types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -303,7 +294,6 @@ func (r *SalesloftConnectionResource) Read(ctx context.Context, req resource.Rea
 		"client_secret":       types.StringType,
 		"connected_user":      types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -390,7 +380,6 @@ func (r *SalesloftConnectionResource) Update(ctx context.Context, req resource.U
 		"client_secret":       types.StringType,
 		"connected_user":      types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/resource_typeform_connection.go
+++ b/provider/internal/connections/resource_typeform_connection.go
@@ -73,13 +73,6 @@ var TypeformSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 			},
 
 			Required: true,
@@ -110,7 +103,6 @@ type TypeformConf struct {
 	Application_id      string `mapstructure:"application_id" tfsdk:"application_id"`
 	Client_secret       string `mapstructure:"client_secret" tfsdk:"client_secret"`
 	Oauth_refresh_token string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry  string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 }
 
 type TypeformConnectionResource struct {
@@ -190,7 +182,6 @@ func (r *TypeformConnectionResource) Create(ctx context.Context, req resource.Cr
 		"application_id":      types.StringType,
 		"client_secret":       types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -264,7 +255,6 @@ func (r *TypeformConnectionResource) Read(ctx context.Context, req resource.Read
 		"application_id":      types.StringType,
 		"client_secret":       types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -348,7 +338,6 @@ func (r *TypeformConnectionResource) Update(ctx context.Context, req resource.Up
 		"application_id":      types.StringType,
 		"client_secret":       types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/resource_upfluence_connection.go
+++ b/provider/internal/connections/resource_upfluence_connection.go
@@ -43,23 +43,6 @@ var UpfluenceSchema = schema.Schema{
 		},
 		"configuration": schema.SingleNestedAttribute{
 			Attributes: map[string]schema.Attribute{
-				"oauth_refresh_token": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           true,
-					PlanModifiers: []planmodifier.String{
-						stringplanmodifier.UseStateForUnknown(),
-					},
-				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 				"password": schema.StringAttribute{
 					MarkdownDescription: ``,
 					Required:            true,
@@ -104,10 +87,8 @@ func (t *UpfluenceConnectionResource) Schema(ctx context.Context, req resource.S
 }
 
 type UpfluenceConf struct {
-	Oauth_refresh_token string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry  string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
-	Password            string `mapstructure:"password" tfsdk:"password"`
-	Username            string `mapstructure:"username" tfsdk:"username"`
+	Password string `mapstructure:"password" tfsdk:"password"`
+	Username string `mapstructure:"username" tfsdk:"username"`
 }
 
 type UpfluenceConnectionResource struct {
@@ -184,10 +165,8 @@ func (r *UpfluenceConnectionResource) Create(ctx context.Context, req resource.C
 	}
 
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
-		"password":            types.StringType,
-		"username":            types.StringType,
+		"password": types.StringType,
+		"username": types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -258,10 +237,8 @@ func (r *UpfluenceConnectionResource) Read(ctx context.Context, req resource.Rea
 	}
 
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
-		"password":            types.StringType,
-		"username":            types.StringType,
+		"password": types.StringType,
+		"username": types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -342,10 +319,8 @@ func (r *UpfluenceConnectionResource) Update(ctx context.Context, req resource.U
 	}
 
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
-		"password":            types.StringType,
-		"username":            types.StringType,
+		"password": types.StringType,
+		"username": types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/provider/internal/connections/resource_youtubeanalytics_connection.go
+++ b/provider/internal/connections/resource_youtubeanalytics_connection.go
@@ -82,13 +82,6 @@ var YoutubeanalyticsSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 				"user_email": schema.StringAttribute{
 					MarkdownDescription: `Connected user's email`,
 					Required:            false,
@@ -127,7 +120,6 @@ type YoutubeanalyticsConf struct {
 	Client_secret       string `mapstructure:"client_secret" tfsdk:"client_secret"`
 	Content_owner_id    string `mapstructure:"content_owner_id" tfsdk:"content_owner_id"`
 	Oauth_refresh_token string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry  string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 	User_email          string `mapstructure:"user_email" tfsdk:"user_email"`
 }
 
@@ -209,7 +201,6 @@ func (r *YoutubeanalyticsConnectionResource) Create(ctx context.Context, req res
 		"client_secret":       types.StringType,
 		"content_owner_id":    types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"user_email":          types.StringType,
 	}, conf)
 	if diags.HasError() {
@@ -285,7 +276,6 @@ func (r *YoutubeanalyticsConnectionResource) Read(ctx context.Context, req resou
 		"client_secret":       types.StringType,
 		"content_owner_id":    types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"user_email":          types.StringType,
 	}, conf)
 	if diags.HasError() {
@@ -371,7 +361,6 @@ func (r *YoutubeanalyticsConnectionResource) Update(ctx context.Context, req res
 		"client_secret":       types.StringType,
 		"content_owner_id":    types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"user_email":          types.StringType,
 	}, conf)
 	if diags.HasError() {

--- a/provider/internal/connections/resource_zendesk_support_connection.go
+++ b/provider/internal/connections/resource_zendesk_support_connection.go
@@ -97,13 +97,6 @@ var Zendesk_supportSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 				"ratelimit_rpm": schema.Int64Attribute{
 					MarkdownDescription: `Maximum requests per minute
 
@@ -146,7 +139,6 @@ type Zendesk_supportConf struct {
 	Domain              string `mapstructure:"domain" tfsdk:"domain"`
 	Email               string `mapstructure:"email" tfsdk:"email"`
 	Oauth_refresh_token string `mapstructure:"oauth_refresh_token" tfsdk:"oauth_refresh_token"`
-	Oauth_token_expiry  string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
 	Ratelimit_rpm       int64  `mapstructure:"ratelimit_rpm" tfsdk:"ratelimit_rpm"`
 }
 
@@ -230,7 +222,6 @@ func (r *Zendesk_supportConnectionResource) Create(ctx context.Context, req reso
 		"domain":              types.StringType,
 		"email":               types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"ratelimit_rpm":       types.NumberType,
 	}, conf)
 	if diags.HasError() {
@@ -308,7 +299,6 @@ func (r *Zendesk_supportConnectionResource) Read(ctx context.Context, req resour
 		"domain":              types.StringType,
 		"email":               types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"ratelimit_rpm":       types.NumberType,
 	}, conf)
 	if diags.HasError() {
@@ -396,7 +386,6 @@ func (r *Zendesk_supportConnectionResource) Update(ctx context.Context, req reso
 		"domain":              types.StringType,
 		"email":               types.StringType,
 		"oauth_refresh_token": types.StringType,
-		"oauth_token_expiry":  types.StringType,
 		"ratelimit_rpm":       types.NumberType,
 	}, conf)
 	if diags.HasError() {

--- a/provider/internal/connections/resource_zoho_crm_connection.go
+++ b/provider/internal/connections/resource_zoho_crm_connection.go
@@ -66,13 +66,6 @@ var Zoho_crmSchema = schema.Schema{
 						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
-				"oauth_token_expiry": schema.StringAttribute{
-					MarkdownDescription: ``,
-					Required:            false,
-					Optional:            true,
-					Computed:            true,
-					Sensitive:           false,
-				},
 				"region": schema.StringAttribute{
 					MarkdownDescription: `Data center region Valid values: <code>usa</code> (USA), <code>europe</code> (Europe), <code>australia</code> (Australia), <code>canada</code> (Canada), <code>china</code> (China), <code>japan</code> (Japan), <code>saudi_arabia</code> (Saudi Arabia). Default: <code>usa</code>.`,
 					Required:            true,
@@ -110,10 +103,9 @@ func (t *Zoho_crmConnectionResource) Schema(ctx context.Context, req resource.Sc
 }
 
 type Zoho_crmConf struct {
-	Client_id          string `mapstructure:"client_id" tfsdk:"client_id"`
-	Client_secret      string `mapstructure:"client_secret" tfsdk:"client_secret"`
-	Oauth_token_expiry string `mapstructure:"oauth_token_expiry" tfsdk:"oauth_token_expiry"`
-	Region             string `mapstructure:"region" tfsdk:"region"`
+	Client_id     string `mapstructure:"client_id" tfsdk:"client_id"`
+	Client_secret string `mapstructure:"client_secret" tfsdk:"client_secret"`
+	Region        string `mapstructure:"region" tfsdk:"region"`
 }
 
 type Zoho_crmConnectionResource struct {
@@ -190,10 +182,9 @@ func (r *Zoho_crmConnectionResource) Create(ctx context.Context, req resource.Cr
 	}
 
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"client_id":          types.StringType,
-		"client_secret":      types.StringType,
-		"oauth_token_expiry": types.StringType,
-		"region":             types.StringType,
+		"client_id":     types.StringType,
+		"client_secret": types.StringType,
+		"region":        types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -264,10 +255,9 @@ func (r *Zoho_crmConnectionResource) Read(ctx context.Context, req resource.Read
 	}
 
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"client_id":          types.StringType,
-		"client_secret":      types.StringType,
-		"oauth_token_expiry": types.StringType,
-		"region":             types.StringType,
+		"client_id":     types.StringType,
+		"client_secret": types.StringType,
+		"region":        types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
@@ -348,10 +338,9 @@ func (r *Zoho_crmConnectionResource) Update(ctx context.Context, req resource.Up
 	}
 
 	data.Configuration, diags = types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"client_id":          types.StringType,
-		"client_secret":      types.StringType,
-		"oauth_token_expiry": types.StringType,
-		"region":             types.StringType,
+		"client_id":     types.StringType,
+		"client_secret": types.StringType,
+		"region":        types.StringType,
 	}, conf)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/templates/guides/upgrading-to-v2.0.0.md
+++ b/templates/guides/upgrading-to-v2.0.0.md
@@ -1,0 +1,89 @@
+---
+page_title: "Upgrading to v2.0.0"
+subcategory: ""
+description: |-
+  Notes on upgrading the Polytomic provider to v2.0.0.
+---
+
+# Upgrading to v2.0.0
+
+Version 2.0.0 removes server-managed internal fields from connection configurations. These fields were never meant to be set or read through Terraform — they track internal state such as whether an OAuth flow has completed (`authenticated`) or when an OAuth token expires (`oauth_token_expiry`). Previously they were generated as `Optional` + `Computed`, so they appeared in the schema and documentation and were even assignable, despite having no effect.
+
+Unlike the server-managed fields addressed in [v1.5.0](upgrading-to-v1.5.0), which carry useful information (such as the connected user) and were made read-only, these fields carry no configuration or reference value. They are now removed entirely.
+
+This affects 28 fields across 27 connection types. Fields that are hidden in the Polytomic UI but settable through the API — such as `client_id`, `client_secret`, and `oauth_access_token` — are unchanged.
+
+## Migration steps
+
+After upgrading, run `terraform plan`.
+
+If a configuration assigns one of the removed fields, Terraform returns an error like:
+
+```
+Error: Unsupported argument
+  on main.tf line 5, in resource "polytomic_github_connection" "example":
+   5:     authenticated = true
+
+An argument named "authenticated" is not expected here.
+```
+
+Remove the assignment from your configuration. These fields were managed by Polytomic, so removing them has no effect on the connection.
+
+```hcl
+# Before (v1.5.x)
+resource "polytomic_github_connection" "example" {
+  name = "GitHub"
+  configuration = {
+    oauth_access_token = var.github_token
+    authenticated      = true # remove this line
+  }
+}
+
+# After (v2.0.0)
+resource "polytomic_github_connection" "example" {
+  name = "GitHub"
+  configuration = {
+    oauth_access_token = var.github_token
+  }
+}
+```
+
+Terraform drops the removed fields from existing state automatically on the next refresh; no manual state changes are required.
+
+If another resource or output references a removed field (for example `polytomic_github_connection.example.configuration.authenticated`), remove that reference — the value is no longer exported.
+
+## Importer
+
+If you generated your configuration with the `polytomic` importer, regenerate it with the v2.0.0 importer to drop the removed fields automatically.
+
+## Affected fields
+
+| Connection | Field(s) |
+|---|---|
+| polytomic_dbtprojectrepository_connection | oauth_token_expiry |
+| polytomic_dialpad_connection | oauth_token_expiry |
+| polytomic_dropbox_connection | oauth_token_expiry |
+| polytomic_github_connection | authenticated |
+| polytomic_gmail_connection | oauth_token_expiry |
+| polytomic_gong_connection | oauth_token_expiry |
+| polytomic_googleads_connection | oauth_token_expiry |
+| polytomic_googleanalytics_connection | oauth_token_expiry |
+| polytomic_googlesearchconsole_connection | oauth_token_expiry |
+| polytomic_googleslides_connection | oauth_token_expiry |
+| polytomic_googleworkspace_connection | oauth_token_expiry |
+| polytomic_gsheets_connection | oauth_token_expiry |
+| polytomic_linkedinads_connection | oauth_token_expiry |
+| polytomic_marketo_connection | oauth_token_expiry |
+| polytomic_msads_connection | oauth_token_expiry |
+| polytomic_msdynamics_connection | oauth_token_expiry |
+| polytomic_outreach_connection | oauth_token_expiry |
+| polytomic_quickbooks_connection | oauth_token_expiry |
+| polytomic_ramp_connection | oauth_token_expiry |
+| polytomic_redditads_connection | oauth_token_expiry |
+| polytomic_sageintacct_connection | oauth_token_expiry |
+| polytomic_salesloft_connection | oauth_token_expiry |
+| polytomic_typeform_connection | oauth_token_expiry |
+| polytomic_upfluence_connection | oauth_refresh_token, oauth_token_expiry |
+| polytomic_youtubeanalytics_connection | oauth_token_expiry |
+| polytomic_zendesk_support_connection | oauth_token_expiry |
+| polytomic_zoho_crm_connection | oauth_token_expiry |

--- a/templates/resources/dbtprojectrepository_connection.md.tmpl
+++ b/templates/resources/dbtprojectrepository_connection.md.tmpl
@@ -58,7 +58,6 @@ state before it will take effect on a destroy operation.
 - `branch` (String) Exposures branch
 - `latest_commit` (Attributes) Most recent exposures commit See [below for nested schema](#nestedatt--configuration--latest_commit).
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 #### Read-Only
 

--- a/templates/resources/dialpad_connection.md.tmpl
+++ b/templates/resources/dialpad_connection.md.tmpl
@@ -55,6 +55,5 @@ state before it will take effect on a destroy operation.
 - `application_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 

--- a/templates/resources/dropbox_connection.md.tmpl
+++ b/templates/resources/dropbox_connection.md.tmpl
@@ -62,7 +62,6 @@ state before it will take effect on a destroy operation.
 
     Treat the files as a single table. Default: <code>false</code>.
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 - `single_table_file_format` (String) File format Valid values: <code>csv</code> (CSV), <code>json</code> (JSON), <code>parquet</code> (Parquet). Default: <code>csv</code>.
 - `single_table_file_formats` (Set of String) File formats
 

--- a/templates/resources/github_connection.md.tmpl
+++ b/templates/resources/github_connection.md.tmpl
@@ -51,7 +51,6 @@ state before it will take effect on a destroy operation.
 
 #### Optional
 
-- `authenticated` (Boolean)
 - `client_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `repositories` (Attributes Set) See [below for nested schema](#nestedatt--configuration--repositories).

--- a/templates/resources/gmail_connection.md.tmpl
+++ b/templates/resources/gmail_connection.md.tmpl
@@ -50,7 +50,6 @@ state before it will take effect on a destroy operation.
 - `client_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 #### Read-Only
 

--- a/templates/resources/gong_connection.md.tmpl
+++ b/templates/resources/gong_connection.md.tmpl
@@ -56,7 +56,6 @@ state before it will take effect on a destroy operation.
 - `client_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 - `subdomain` (String) Gong subdomain i.e. company-17 if you access Gong via https://company-17.app.gong.io
 
 

--- a/templates/resources/googleads_connection.md.tmpl
+++ b/templates/resources/googleads_connection.md.tmpl
@@ -57,7 +57,6 @@ state before it will take effect on a destroy operation.
 
     One report per line. Format is a report name:ads object:field list. e.g. myReport:ad_groups:campaign.id
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 #### Read-Only
 

--- a/templates/resources/googleanalytics_connection.md.tmpl
+++ b/templates/resources/googleanalytics_connection.md.tmpl
@@ -57,7 +57,6 @@ state before it will take effect on a destroy operation.
 
     One report per line. Format is a report name followed by a comma-separated list of fields. e.g. myReport:field1
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 - `properties` (Attributes Set) See [below for nested schema](#nestedatt--configuration--properties).
 - `service_account` (String, Sensitive) Service account key
 

--- a/templates/resources/googlesearchconsole_connection.md.tmpl
+++ b/templates/resources/googlesearchconsole_connection.md.tmpl
@@ -50,7 +50,6 @@ state before it will take effect on a destroy operation.
 - `client_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 - `sites` (Attributes Set) See [below for nested schema](#nestedatt--configuration--sites).
 
 

--- a/templates/resources/googleslides_connection.md.tmpl
+++ b/templates/resources/googleslides_connection.md.tmpl
@@ -56,7 +56,6 @@ state before it will take effect on a destroy operation.
 - `connect_mode` (String) Default: browser Valid values: <code>browser</code>, <code>jwt</code>. Default: <code>browser</code>.
 - `include_subdirectories` (Boolean) Include Subdirectories Default: <code>false</code>.
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 - `service_account` (String, Sensitive) Service account key
 
 #### Read-Only

--- a/templates/resources/googleworkspace_connection.md.tmpl
+++ b/templates/resources/googleworkspace_connection.md.tmpl
@@ -51,7 +51,6 @@ state before it will take effect on a destroy operation.
 - `client_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `customer_id` (String) Customer ID
-- `oauth_token_expiry` (String)
 - `service_account` (String, Sensitive) Service account key
 
 #### Read-Only

--- a/templates/resources/gsheets_connection.md.tmpl
+++ b/templates/resources/gsheets_connection.md.tmpl
@@ -56,7 +56,6 @@ state before it will take effect on a destroy operation.
 - `connect_mode` (String) Default: browser Valid values: <code>browser</code>, <code>jwt</code>. Default: <code>browser</code>.
 - `has_headers` (Boolean) Columns have headers
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 - `service_account` (String, Sensitive) Service account key
 
 #### Read-Only

--- a/templates/resources/linkedinads_connection.md.tmpl
+++ b/templates/resources/linkedinads_connection.md.tmpl
@@ -51,7 +51,6 @@ state before it will take effect on a destroy operation.
 - `client_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 #### Read-Only
 

--- a/templates/resources/marketo_connection.md.tmpl
+++ b/templates/resources/marketo_connection.md.tmpl
@@ -57,6 +57,5 @@ state before it will take effect on a destroy operation.
 - `daily_api_calls` (Number) Daily call limit Default: <code>37500</code>.
 - `enforce_api_limits` (Boolean) Enforce API limits
 - `include_static_lists` (Boolean) Include static list support Default: <code>true</code>.
-- `oauth_token_expiry` (String)
 
 

--- a/templates/resources/msads_connection.md.tmpl
+++ b/templates/resources/msads_connection.md.tmpl
@@ -53,7 +53,6 @@ state before it will take effect on a destroy operation.
 - `client_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 #### Read-Only
 

--- a/templates/resources/msdynamics_connection.md.tmpl
+++ b/templates/resources/msdynamics_connection.md.tmpl
@@ -54,6 +54,5 @@ state before it will take effect on a destroy operation.
 - `client_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 

--- a/templates/resources/outreach_connection.md.tmpl
+++ b/templates/resources/outreach_connection.md.tmpl
@@ -50,7 +50,6 @@ state before it will take effect on a destroy operation.
 - `client_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 - `use_bulk_upsert` (Boolean) Use bulk API for syncing to Outreach Default: <code>true</code>.
 
 #### Read-Only

--- a/templates/resources/quickbooks_connection.md.tmpl
+++ b/templates/resources/quickbooks_connection.md.tmpl
@@ -54,6 +54,5 @@ state before it will take effect on a destroy operation.
 - `client_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 

--- a/templates/resources/ramp_connection.md.tmpl
+++ b/templates/resources/ramp_connection.md.tmpl
@@ -51,6 +51,5 @@ state before it will take effect on a destroy operation.
 - `client_secret` (String, Sensitive)
 - `is_sandbox` (Boolean) Is Sandbox
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 

--- a/templates/resources/redditads_connection.md.tmpl
+++ b/templates/resources/redditads_connection.md.tmpl
@@ -51,7 +51,6 @@ state before it will take effect on a destroy operation.
 - `application_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 - `pixel_id` (String) Conversion Pixel ID
 
     Required if syncing conversion events to Reddit Ads.

--- a/templates/resources/sageintacct_connection.md.tmpl
+++ b/templates/resources/sageintacct_connection.md.tmpl
@@ -50,6 +50,5 @@ state before it will take effect on a destroy operation.
 - `application_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 

--- a/templates/resources/salesloft_connection.md.tmpl
+++ b/templates/resources/salesloft_connection.md.tmpl
@@ -55,7 +55,6 @@ state before it will take effect on a destroy operation.
 - `application_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 #### Read-Only
 

--- a/templates/resources/typeform_connection.md.tmpl
+++ b/templates/resources/typeform_connection.md.tmpl
@@ -50,6 +50,5 @@ state before it will take effect on a destroy operation.
 - `application_id` (String, Sensitive)
 - `client_secret` (String, Sensitive)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 

--- a/templates/resources/upfluence_connection.md.tmpl
+++ b/templates/resources/upfluence_connection.md.tmpl
@@ -50,9 +50,4 @@ state before it will take effect on a destroy operation.
 - `password` (String, Sensitive)
 - `username` (String) Email
 
-#### Optional
-
-- `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
-
 

--- a/templates/resources/youtubeanalytics_connection.md.tmpl
+++ b/templates/resources/youtubeanalytics_connection.md.tmpl
@@ -53,7 +53,6 @@ state before it will take effect on a destroy operation.
 
     If you are using a content owner account enter the content owner ID here. This is required for some reports.
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 
 #### Read-Only
 

--- a/templates/resources/zendesk_support_connection.md.tmpl
+++ b/templates/resources/zendesk_support_connection.md.tmpl
@@ -56,7 +56,6 @@ state before it will take effect on a destroy operation.
 - `custom_api_limits` (Boolean) Enforce custom API limits
 - `email` (String)
 - `oauth_refresh_token` (String, Sensitive)
-- `oauth_token_expiry` (String)
 - `ratelimit_rpm` (Number) Maximum requests per minute
 
     Set a custom maximum request per minute limit.

--- a/templates/resources/zoho_crm_connection.md.tmpl
+++ b/templates/resources/zoho_crm_connection.md.tmpl
@@ -53,6 +53,5 @@ state before it will take effect on a destroy operation.
 
 - `client_id` (String, Sensitive) Client ID
 - `client_secret` (String, Sensitive) Client secret
-- `oauth_token_expiry` (String)
 
 


### PR DESCRIPTION
Connection-type JSON schemas mark some fields hidden=true. A subset of these (client_id, client_secret, oauth_access_token) also carry api_field=true: they are hidden in the UI but legitimately settable via the API. The rest (authenticated, oauth_token_expiry, oauth_refresh_token) are pure internal/server-managed state that the backend overwrites and that has no configuration or reference value in Terraform.

The generator only inspected the `sensitive` marker, so it emitted these internal fields as Optional+Computed attributes — visible in the schema and docs, and even assignable, despite having no effect.

Filter them out in the connection generator using the per-field flags (hidden && !api_field). The same field name can be api_field in one backend and internal in another (e.g. oauth_refresh_token is api_field in 33 backends but internal in upfluence), so this must be decided per-field rather than from a name blocklist. Removing the attribute at the extraction point propagates consistently to the schema, the *Conf struct, the ObjectValueFrom attr-type maps, docs, and examples.

This removes 28 fields across 27 connection types. The importer needs no change: it already filters config to fields present in the schema.

BREAKING CHANGE: bumped to v2.0.0; see upgrade guide for the field list and migration steps.